### PR TITLE
Improve cli interface and user experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@ Usage
 
 ```
 USAGE:
-    elf2tab [FLAGS] [OPTIONS] --app-heap <APP_HEAP_SIZE> --kernel-heap <KERNEL_HEAP_SIZE> --stack <STACK_SIZE> -o <TAB> [ELF]...
+    elf2tab [FLAGS] [--protected-region-size=<protected-region-size>]
+                    [--package-name=<pkg-name>] [--output-file=<filename>] <elf>...
+    elf2tab [FLAGS] [--proteced-region-size=<protected-region-size>] [--package-name=<pkg-name>]
+                    [--output-file=<filename>] [--minimum-ram-size=<min-ram-size>] <elf>...
+    elf2tab [FLAGS] [--proteced-region-size=<protected-region-size>]
+                    [--package-name=<pkg-name>] [--output-file=<filename>]
+                    [--app-heap=<heap-size>] [--kernel-heap=<kernel-heap-size>] [--stack=<stack-size>] <elf>...
 
 FLAGS:
     -h, --help       Prints help information
@@ -19,14 +25,16 @@ FLAGS:
     -v, --verbose    Be verbose
 
 OPTIONS:
-        --app-heap <APP_HEAP_SIZE>          App heap size in bytes
-        --kernel-heap <KERNEL_HEAP_SIZE>    Kernel heap size in bytes
-    -n <PACKAGE_NAME>                       Package Name
-        --stack <STACK_SIZE>                Stack size in bytes
-    -o <TAB>                                Output file name
+    -o, --output-file <filename>             output file name [default: TockApp.tab]
+        --app-heap <heap-size>               in bytes [default: 1024]
+        --kernel-heap <kernel-heap-size>     in bytes [default: 1024]
+        --minimum-ram-size <min-ram-size>    in bytes
+    -p, --package-name <pkg-name>            package name
+        --protected-region-size <protected-region-size>    Size of the protected region (including headers)
+        --stack <stack-size>                 in bytes [default: 2048]
 
 ARGS:
-    <ELF>...    App elf files
+    <elf>...    application file(s) to package
 ```
 
 For example, converting a "blink" app from a compiled .elf file (for a Cortex-M4
@@ -37,7 +45,7 @@ device) with this tool would look like:
 It also supports (and encourages!) combing .elf files for multiple architectures
 into a single tab:
 
-	$ elf2tab -o blink.tab -n blink --stack 1024 --app-heap 1024 --kernel-heap 1024 cortex-m0.elf cortex-m3.elf cortex-m4.elf
+    $ elf2tab -o blink.tab -n blink --stack 1024 --app-heap 1024 --kernel-heap 1024 cortex-m0.elf cortex-m3.elf cortex-m4.elf
 
 
 Compiling elf2tab

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -2,10 +2,13 @@ use std::path::PathBuf;
 use structopt;
 
 fn usage() -> &'static str {
-    "elf2tab [FLAGS] [--package-name=<pkg-name>] [--output-file=<filename>] <elf>...
-    elf2tab [FLAGS] [--package-name=<pkg-name>] [--output-file=<filename>] [--minimum-ram-size=<min-ram-size>] <elf>...
-    elf2tab [FLAGS] [--package-name=<pkg-name>] [--output-file=<filename>] [--app-heap=<heap-size>]
-                    [--kernel-heap=<kernel-heap-size>] [--stack=<stack-size>] <elf>..."
+    "elf2tab [FLAGS] [--protected-region-size=<protected-region-size>]
+                    [--package-name=<pkg-name>] [--output-file=<filename>] <elf>...
+    elf2tab [FLAGS] [--proteced-region-size=<protected-region-size>] [--package-name=<pkg-name>]
+                    [--output-file=<filename>] [--minimum-ram-size=<min-ram-size>] <elf>...
+    elf2tab [FLAGS] [--proteced-region-size=<protected-region-size>]
+                    [--package-name=<pkg-name>] [--output-file=<filename>]
+                    [--app-heap=<heap-size>] [--kernel-heap=<kernel-heap-size>] [--stack=<stack-size>] <elf>..."
 }
 
 #[derive(StructOpt, Debug)]
@@ -77,15 +80,13 @@ pub struct Opt {
     )]
     #[structopt(raw(required = "true"))]
     pub input: Vec<PathBuf>,
-	
+
     #[structopt(
         long = "protected-region-size",
-        name = "PROTECTED_REGION_SIZE",
+        name = "protected-region-size",
         help = "Size of the protected region (including headers)"
     )]
     pub protected_region_size: Option<u32>,
-
-
 }
 
 mod test {

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -1,30 +1,44 @@
 use std::path::PathBuf;
+use structopt;
+use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
 #[structopt(
     about = "Convert Tock userland apps from .elf files to Tock Application Bundles (TABs or .tab files)."
 )]
+#[structopt(raw(setting = "structopt::clap::AppSettings::ColoredHelp"))]
 pub struct Opt {
     #[structopt(short = "v", long = "verbose", help = "Be verbose")]
     pub verbose: bool,
 
-    #[structopt(short = "o", name = "TAB", parse(from_os_str), help = "Output file name")]
+    #[structopt(name = "TABFILE", parse(from_os_str), help = "output file name")]
     pub output: PathBuf,
 
-    #[structopt(short = "n", name = "PACKAGE_NAME", help = "Package Name")]
+    #[structopt(
+        long = "package-name",
+        short = "n",
+        name = "NAME",
+        help = "Package Name"
+    )]
     pub package_name: Option<String>,
 
-    #[structopt(long = "stack", name = "STACK_SIZE", help = "Stack size in bytes")]
+    #[structopt(name = "STACK_SIZE", help = "in bytes")]
     pub stack_size: u32,
 
-    #[structopt(long = "app-heap", name = "APP_HEAP_SIZE", help = "App heap size in bytes")]
+    #[structopt(name = "APP_HEAP_SIZE", help = "in bytes")]
     pub app_heap_size: u32,
 
-    #[structopt(
-        long = "kernel-heap", name = "KERNEL_HEAP_SIZE", help = "Kernel heap size in bytes"
-    )]
+    #[structopt(name = "KERNEL_HEAP_SIZE", help = "in bytes")]
     pub kernel_heap_size: u32,
 
+    #[structopt(
+        name = "ELF",
+        help = "application file(s) to package",
+        parse(from_os_str)
+    )]
+    #[structopt(raw(required = "true"))]
+    pub input: Vec<PathBuf>,
+	
     #[structopt(
         long = "protected-region-size",
         name = "PROTECTED_REGION_SIZE",
@@ -32,6 +46,25 @@ pub struct Opt {
     )]
     pub protected_region_size: Option<u32>,
 
-    #[structopt(name = "ELF", help = "App elf files", parse(from_os_str))]
-    pub input: Vec<PathBuf>,
+
+}
+
+mod test {
+
+    use super::Opt;
+    use super::*;
+
+    #[test]
+    fn succeeds_if_all_required_arguments_are_specified() {
+        let args = vec!["elf2tab", "out.tab", "1024", "2048", "4098", "app.elf"];
+        let result = Opt::from_iter_safe(args.iter());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn fails_if_required_arguments_are_missing() {
+        let args = vec!["out.tab", "1024", "2048", "4098", "app.elf"];
+        let result = Opt::from_iter_safe(args.iter());
+        assert!(result.is_err());
+    }
 }

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -1,7 +1,5 @@
 use std::path::PathBuf;
 use structopt;
-use structopt::clap::ArgGroup;
-use structopt::StructOpt;
 
 fn usage() -> &'static str {
     "elf2tab [FLAGS] [--package-name=<pkg-name>] [--output-file=<filename>] <elf>...
@@ -92,8 +90,10 @@ pub struct Opt {
 
 mod test {
 
+    #[cfg(test)]
     use super::Opt;
-    use super::*;
+    #[cfg(test)]
+    use structopt::StructOpt;
 
     #[test]
     // elf2tab [FLAGS] [--package-name=<pkg-name>] [--output-file=[<filename>]] <elf>...

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -52,7 +52,7 @@ pub struct Opt {
     #[structopt(
         long = "stack",
         name = "stack-size",
-        default_value = "0",
+        default_value = "2048",
         help = "in bytes"
     )]
     pub stack_size: u32,
@@ -60,7 +60,7 @@ pub struct Opt {
     #[structopt(
         long = "app-heap",
         name = "heap-size",
-        default_value = "0",
+        default_value = "1024",
         help = "in bytes"
     )]
     pub app_heap_size: u32,
@@ -68,7 +68,7 @@ pub struct Opt {
     #[structopt(
         long = "kernel-heap",
         name = "kernel-heap-size",
-        default_value = "0",
+        default_value = "1024",
         help = "in bytes"
     )]
     pub kernel_heap_size: u32,

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -4,10 +4,10 @@ use structopt::clap::ArgGroup;
 use structopt::StructOpt;
 
 fn usage() -> &'static str {
-    "elf2tab [FLAGS] [--package-name=<pkg-name>] [--output-file=[<filename>]] <elf>...
-    elf2tab [FLAGS] [--package-name=<pkg-name>] [--output-file=[<filename>]] [--minimum-stack-size=<min-stack-size>] <elf>...
-    elf2tab [FLAGS] [--package-name=<pkg-name>] [--output-file=[<filename>]] [--app-heap[=<heap-size>]]
-                    [--kernel-heap[=<kernel-heap-size>]] [--stack[=<stack-size>]] <elf>..."
+    "elf2tab [FLAGS] [--package-name=<pkg-name>] [--output-file=<filename>] <elf>...
+    elf2tab [FLAGS] [--package-name=<pkg-name>] [--output-file=<filename>] [--minimum-ram-size=<min-ram-size>] <elf>...
+    elf2tab [FLAGS] [--package-name=<pkg-name>] [--output-file=<filename>] [--app-heap=<heap-size>]
+                    [--kernel-heap=<kernel-heap-size>] [--stack=<stack-size>] <elf>..."
 }
 
 #[derive(StructOpt, Debug)]
@@ -21,8 +21,8 @@ pub struct Opt {
     pub verbose: bool,
 
     #[structopt(
-        long = "minimum-stack-size",
-        name = "min-stack-size",
+        long = "minimum-ram-size",
+        name = "min-ram-size",
         help = "in bytes",
         conflicts_with = "stack-size",
         conflicts_with = "heap-size",
@@ -52,8 +52,7 @@ pub struct Opt {
         long = "stack",
         name = "stack-size",
         default_value = "0",
-        help = "in bytes",
-        conflicts_with = "debug"
+        help = "in bytes"
     )]
     pub stack_size: u32,
 
@@ -61,8 +60,7 @@ pub struct Opt {
         long = "app-heap",
         name = "heap-size",
         default_value = "0",
-        help = "in bytes",
-        conflicts_with = "minimum-stack-size"
+        help = "in bytes"
     )]
     pub app_heap_size: u32,
 
@@ -70,8 +68,7 @@ pub struct Opt {
         long = "kernel-heap",
         name = "kernel-heap-size",
         default_value = "0",
-        help = "in bytes",
-        conflicts_with = "minimum-stack-size"
+        help = "in bytes"
     )]
     pub kernel_heap_size: u32,
 
@@ -154,7 +151,7 @@ mod test {
                 "elf2tab",
                 "--package-name",
                 "my-pkg",
-                "--minimum-stack-size",
+                "--minimum-ram-size",
                 "10",
                 "app.elf",
             ];
@@ -171,7 +168,7 @@ mod test {
                 "elf2tab",
                 "--package-name",
                 "my-pkg",
-                "--minimum-stack-size",
+                "--minimum-ram-size",
                 "app.elf",
             ];
             let result = Opt::from_iter_safe(args.iter());
@@ -182,7 +179,7 @@ mod test {
                 "elf2tab",
                 "--package-name",
                 "my-pkg",
-                "--minimum-stack-size",
+                "--minimum-ram-size",
                 "10",
                 "--app-heap",
                 "10",
@@ -196,7 +193,7 @@ mod test {
                 "elf2tab",
                 "--package-name",
                 "my-pkg",
-                "--minimum-stack-size",
+                "--minimum-ram-size",
                 "10",
                 "--stack",
                 "10",
@@ -210,7 +207,7 @@ mod test {
                 "elf2tab",
                 "--package-name",
                 "my-pkg",
-                "--minimum-stack-size",
+                "--minimum-ram-size",
                 "10",
                 "--kernel-heap",
                 "10",
@@ -290,7 +287,7 @@ mod test {
                 "my-pkg",
                 "--kernel-heap",
                 "10",
-                "--minimum-stack-size",
+                "--minimum-ram-size",
                 "10",
                 "app.elf",
             ];
@@ -304,7 +301,7 @@ mod test {
                 "my-pkg",
                 "--app-heap",
                 "10",
-                "--minimum-stack-size",
+                "--minimum-ram-size",
                 "10",
                 "app.elf",
             ];
@@ -318,7 +315,7 @@ mod test {
                 "my-pkg",
                 "--stack",
                 "10",
-                "--minimum-stack-size",
+                "--minimum-ram-size",
                 "10",
                 "app.elf",
             ];


### PR DESCRIPTION
1. Remove "required" options

    elf2tab have had required options, these generaly should be avoided,
    because they have various usability drawbacks:

    * It forces the user not only to specify the values, but also
          to specify the option long/short - name
    * The usage / help does not make it immediatly clear they they are
          required (a user generally expects an option to be optional)

    Therefore "required options" should be replaced either with either:

    * options which have a reasonable default
    * or with required arguments

2. Add color

    Color will make it easier to read.

3. Ensure at lest one application elf file has to be specified

    The previous implementation and usage of the cli suggested that the
    ELF paramater(s) are completely optional.

4. Add basic tests for required parameters

5. Bump version number

    Increase patch version number so its clear there have been some
    changes.