### PR TITLE
Implement a --protected-region-size flag to force a specific protected region size.

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -25,6 +25,13 @@ pub struct Opt {
     )]
     pub kernel_heap_size: u32,
 
+    #[structopt(
+        long = "protected-region-size",
+        name = "PROTECTED_REGION_SIZE",
+        help = "Size of the protected region (including headers)"
+    )]
+    pub protected_region_size: Option<u32>,
+
     #[structopt(name = "ELF", help = "App elf files", parse(from_os_str))]
     pub input: Vec<PathBuf>,
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -209,6 +209,13 @@ impl TbfHeader {
         self.generate().unwrap().get_ref().len()
     }
 
+    /// Update the header with the correct protected_size. protected_size should
+    /// not include the size of the header itself (as defined in the Main TLV
+    /// element type).
+    pub fn set_protected_size(&mut self, protected_size: u32) {
+        self.hdr_main.protected_size = protected_size;
+    }
+
     /// Update the header with correct size for the entire app binary.
     pub fn set_total_size(&mut self, total_size: u32) {
         self.hdr_base.total_size = total_size;


### PR DESCRIPTION
Statically-linked binaries need to know (at compilation time, before elf2tab runs) where they are located. Application code begins after the protected region size of a Tock binary, which is at least the size of the header. `--protected-region-size` allows application Makefiles to specify how large that region is. If the header does not fit in the region, elf2tab will return an error.