### PR TITLE
Update toolchain file to use stable rust.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2018-04-19
+stable


### PR DESCRIPTION
Currently, we don't use unstable features from the 2018-04-19 nightly, hence I set the toolchain to stable.