### PR TITLE
Update the elf2tab version in Cargo.lock.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "elf2tab"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "elf 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
As-is, building elf2tab with `cargo build` causes `cargo` to update this version number, leaving a local change in the elf2tab repository. This change lets us run `cargo build` without generating local changes.