### PR TITLE
Driver Permissions Policy companion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "elf2tab"
-version = "0.4.0"
+version = "0.5.0-dev"
 dependencies = [
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "elf 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -14,6 +14,14 @@ pub struct Opt {
     #[structopt(short = "n", name = "PACKAGE_NAME", help = "Package Name")]
     pub package_name: Option<String>,
 
+    #[structopt(
+        short = "p",
+        long = "permissions",
+        name = "PERMISSIONS",
+        help = "allow certain driver numbers (and disallow all others)"
+    )]
+    pub permissions: Vec<u32>,
+
     #[structopt(long = "stack", name = "STACK_SIZE", help = "Stack size in bytes")]
     pub stack_size: u32,
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -61,7 +61,7 @@ struct TbfHeaderWriteableFlashRegion {
 #[derive(Clone, Copy, Debug)]
 struct TbfHeaderPerm {
     base: TbfHeaderTlv,
-    permissions: [u32; DEFAULT_PERMS_LENGTH],
+    permissions: &'static [u32],
 }
 
 impl fmt::Display for TbfHeaderBase {
@@ -168,7 +168,7 @@ impl TbfHeader {
                     length: (mem::size_of::<TbfHeaderPerm>() - mem::size_of::<TbfHeaderTlv>())
                         as u16,
                 },
-                permissions: DEFAULT_PERMS,
+                permissions: &DEFAULT_PERMS,
             },
             package_name: String::new(),
             package_name_pad: 0,
@@ -187,6 +187,7 @@ impl TbfHeader {
         minimum_ram_size: u32,
         writeable_flash_regions: usize,
         package_name: String,
+        permissions: &'static [u32],
     ) -> usize {
         // Need to calculate lengths ahead of time.
         // Need the base and the main section.
@@ -217,6 +218,7 @@ impl TbfHeader {
         self.hdr_base.header_size = header_length as u16;
         self.hdr_base.flags = flags;
         self.hdr_main.minimum_ram_size = minimum_ram_size;
+        self.hdr_perm.permissions = permissions;
 
         // If a package name exists, keep track of it and add it to the header.
         self.package_name = package_name;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,9 @@ use structopt::StructOpt;
 
 fn main() {
     let opt = cmdline::Opt::from_args();
+    let mut perms_mut = opt.permissions.to_vec();
+    perms_mut.sort(); // for binary search
+    let perms = perms_mut.as_slice();
 
     // Create the metadata.toml file needed for the TAB file.
     let mut metadata_toml = String::new();
@@ -69,6 +72,7 @@ build-date = {}",
             opt.stack_size,
             opt.app_heap_size,
             opt.kernel_heap_size,
+            perms,
             opt.protected_region_size,
         ).unwrap();
 
@@ -103,6 +107,7 @@ fn elf_to_tbf(
     stack_len: u32,
     app_heap_len: u32,
     kernel_heap_len: u32,
+    permissions: &'static [u32],
     protected_region_size_arg: Option<u32>,
 ) -> io::Result<()> {
     let package_name = package_name.unwrap_or(String::new());
@@ -178,6 +183,7 @@ fn elf_to_tbf(
         minimum_ram_size,
         writeable_flash_regions_count,
         package_name,
+        permissions,
     );
     // If a protected region size was passed, confirm the header will fit.
     // Otherwise, use the header size as the protected region size.


### PR DESCRIPTION
### Pull Request Overview

This PR goes hand in hand with [tock PR #1300](https://github.com/tock/tock/pull/1300). This update to elf2tab allows elf2tab to write permission bytes to TAB files. Tock OS will check these bytes to see if an application is allowed permission to any given driver. Permission bytes form a bitmap, with a driver allowed if its corresponding bit is set to 1. Permission bits can be flipped using tockloader in a coming PR.

Merging this will cause a warning to appear when using the current version of tockloader: 
```
Warning: Unknown TLV block in TBF header: 5.
Warning: You might want to update tockloader.
```
However, this PR shouldn't cause any errors; the permissions header will just be ignored if the version of tockloader doesn't support the feature.

### Help wanted

To know how many bytes to leave blank for permissions, elf2tab needs to know the number of drivers. This results in a `const NUM_DRIVERS` at the top of header.rs which must be incremented each time a driver is add in tock. Is there a better way?