### PR TITLE
Panic if the tab and output file are the same

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,12 @@ build-date = {}",
         let tbf_path = elf_path.with_extension("tbf");
 
         let elffile = elf::File::open_path(&elf_path).expect("Could not open the .elf file.");
+
+        if opt.output.clone() == tbf_path.clone() {
+            panic!("tab file {} and output file {} cannot be the same file",
+                   opt.output.clone().to_str().unwrap(), tbf_path.clone().to_str().unwrap());
+        }
+
         // Get output file as both read/write for creating the binary and
         // adding it to the TAB tar file.
         let mut outfile: fs::File = fs::OpenOptions::new()


### PR DESCRIPTION
If a user specifies the tab file to be the same as the output file
elf2tab will loop forver creating an infinite size file. To avoid this
happening to users let's check if they are the same and panic if they
are.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>