### PR TITLE
Apply various cleanups: formatting, build warnings, Clippy

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -203,7 +203,10 @@ impl TbfHeader {
         }
 
         // Return the length by generating the header and seeing how long it is.
-        self.generate().expect("No header was generated").get_ref().len()
+        self.generate()
+            .expect("No header was generated")
+            .get_ref()
+            .len()
     }
 
     /// Update the header with the correct protected_size. protected_size should

--- a/src/header.rs
+++ b/src/header.rs
@@ -239,7 +239,7 @@ impl TbfHeader {
     }
 
     /// Create the header in binary form.
-    pub fn generate(&self) -> io::Result<(io::Cursor<vec::Vec<u8>>)> {
+    pub fn generate(&self) -> io::Result<io::Cursor<vec::Vec<u8>>> {
         let mut header_buf = io::Cursor::new(Vec::new());
 
         // Write all bytes to an in-memory file for the header.
@@ -267,7 +267,7 @@ impl TbfHeader {
     fn inject_checksum(
         &self,
         mut header_buf: io::Cursor<vec::Vec<u8>>,
-    ) -> io::Result<(io::Cursor<vec::Vec<u8>>)> {
+    ) -> io::Result<io::Cursor<vec::Vec<u8>>> {
         // Start from the beginning and iterate through the buffer as words.
         header_buf.seek(SeekFrom::Start(0))?;
         let mut wordbuf = [0_u8; 4];

--- a/src/header.rs
+++ b/src/header.rs
@@ -51,55 +51,40 @@ struct TbfHeaderWriteableFlashRegion {
 
 impl fmt::Display for TbfHeaderBase {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
+        writeln!(
             f,
             "
-               version: {:>8} {:>#10X}
-           header_size: {:>8} {:>#10X}
-            total_size: {:>8} {:>#10X}
-                 flags: {:>8} {:>#10X}
-",
-            self.version,
-            self.version,
-            self.header_size,
-            self.header_size,
-            self.total_size,
-            self.total_size,
-            self.flags,
-            self.flags,
+               version: {0:>8} {0:>#10X}
+           header_size: {1:>8} {1:>#10X}
+            total_size: {2:>8} {2:>#10X}
+                 flags: {3:>8} {3:>#10X}",
+            self.version, self.header_size, self.total_size, self.flags,
         )
     }
 }
 
 impl fmt::Display for TbfHeaderMain {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
+        writeln!(
             f,
             "
-        init_fn_offset: {:>8} {:>#10X}
-        protected_size: {:>8} {:>#10X}
-      minimum_ram_size: {:>8} {:>#10X}
-",
-            self.init_fn_offset,
-            self.init_fn_offset,
-            self.protected_size,
-            self.protected_size,
-            self.minimum_ram_size,
-            self.minimum_ram_size,
+        init_fn_offset: {0:>8} {0:>#10X}
+        protected_size: {1:>8} {1:>#10X}
+      minimum_ram_size: {2:>8} {2:>#10X}",
+            self.init_fn_offset, self.protected_size, self.minimum_ram_size,
         )
     }
 }
 
 impl fmt::Display for TbfHeaderWriteableFlashRegion {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
+        writeln!(
             f,
             "
     flash region:
-                offset: {:>8} {:>#10X}
-                  size: {:>8} {:>#10X}
-",
-            self.offset, self.offset, self.size, self.size,
+                offset: {0:>8} {0:>#10X}
+                  size: {1:>8} {1:>#10X}",
+            self.offset, self.size,
         )
     }
 }
@@ -293,7 +278,7 @@ impl TbfHeader {
         wordbuf[1] = ((checksum >> 8) & 0xFF) as u8;
         wordbuf[2] = ((checksum >> 16) & 0xFF) as u8;
         wordbuf[3] = ((checksum >> 24) & 0xFF) as u8;
-        header_buf.write(&wordbuf)?;
+        header_buf.write_all(&wordbuf)?;
         header_buf.seek(io::SeekFrom::Start(0))?;
 
         Ok(header_buf)

--- a/src/main.rs
+++ b/src/main.rs
@@ -265,13 +265,15 @@ fn elf_to_tbf<W: Write>(
         {
             if verbose {
                 println!(
-                    "Including the {} section at offset {} (0x{:x})",
-                    section.shdr.name, binary_index, binary_index
+                    "  Adding {0} section. Offset: {1} ({1:#x}). Length: {2} ({2:#x}) bytes.",
+                    section.shdr.name,
+                    binary_index,
+                    section.data.len(),
                 );
             }
             if align4needed!(binary_index) != 0 {
                 println!(
-                    "Warning! Placing section {} at 0x{:x}, which is not 4-byte aligned.",
+                    "Warning! Placing section {} at {:#x}, which is not 4-byte aligned.",
                     section.shdr.name, binary_index
                 );
             }
@@ -317,16 +319,15 @@ fn elf_to_tbf<W: Write>(
 
         if verbose && !rel_data.is_empty() {
             println!(
-                "  Adding {} section. Length: {} bytes at {} (0x{:x})",
+                "  Adding {0} section. Offset: {1} ({1:#x}). Length: {2} ({2:#x}) bytes.",
                 name,
-                rel_data.len(),
                 binary_index + mem::size_of::<u32>() + rel_data.len(),
-                binary_index + mem::size_of::<u32>() + rel_data.len()
+                rel_data.len(),
             );
         }
         if !rel_data.is_empty() && align4needed!(binary_index) != 0 {
             println!(
-                "Warning! Placing section {} at 0x{:x}, which is not 4-byte aligned.",
+                "Warning! Placing section {} at {:#x}, which is not 4-byte aligned.",
                 name, binary_index
             );
         }
@@ -359,12 +360,7 @@ fn elf_to_tbf<W: Write>(
     output.write_all(tbfheader.generate().unwrap().get_ref())?;
     output.write_all(binary.as_ref())?;
 
-    let rel_data_len: [u8; 4] = [
-        (relocation_binary.len() & 0xff) as u8,
-        (relocation_binary.len() >> 8 & 0xff) as u8,
-        (relocation_binary.len() >> 16 & 0xff) as u8,
-        (relocation_binary.len() >> 24 & 0xff) as u8,
-    ];
+    let rel_data_len: [u8; 4] = (relocation_binary.len() as u32).to_le_bytes();
     output.write_all(&rel_data_len)?;
     output.write_all(relocation_binary.as_ref())?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ build-date = {}",
             panic!(
                 "tab file {} and output file {} cannot be the same file",
                 opt.output.clone().to_str().unwrap(),
-                tbf_path.clone().to_str().unwrap()
+                tbf_path.to_str().unwrap()
             );
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,9 +28,12 @@ fn main() {
 name = \"{}\"
 only-for-boards = \"\"
 build-date = {}",
-        opt.package_name.as_ref().map_or("", |package_name| package_name.as_str()),
+        opt.package_name
+            .as_ref()
+            .map_or("", |package_name| package_name.as_str()),
         chrono::prelude::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
-    ).unwrap();
+    )
+    .unwrap();
 
     // Start creating a tar archive which will be the .tab file.
     let tab_name = fs::File::create(&opt.output).expect("Could not create the output file.");
@@ -52,8 +55,11 @@ build-date = {}",
         let elffile = elf::File::open_path(&elf_path).expect("Could not open the .elf file.");
 
         if opt.output.clone() == tbf_path.clone() {
-            panic!("tab file {} and output file {} cannot be the same file",
-                   opt.output.clone().to_str().unwrap(), tbf_path.clone().to_str().unwrap());
+            panic!(
+                "tab file {} and output file {} cannot be the same file",
+                opt.output.clone().to_str().unwrap(),
+                tbf_path.clone().to_str().unwrap()
+            );
         }
 
         // Get output file as both read/write for creating the binary and
@@ -76,7 +82,8 @@ build-date = {}",
             opt.app_heap_size,
             opt.kernel_heap_size,
             opt.protected_region_size,
-        ).unwrap();
+        )
+        .unwrap();
 
         // Add the file to the TAB tar file.
         outfile.seek(io::SeekFrom::Start(0)).unwrap();
@@ -86,7 +93,8 @@ build-date = {}",
         tab.append_file(
             tbf_path.with_extension("bin").file_name().unwrap(),
             &mut outfile,
-        ).unwrap();
+        )
+        .unwrap();
     }
 }
 
@@ -251,7 +259,8 @@ fn elf_to_tbf(
         // and is type `PROGBITS` we want to add it to the binary.
         if (section.shdr.flags.0
             & (elf::types::SHF_WRITE.0 + elf::types::SHF_EXECINSTR.0 + elf::types::SHF_ALLOC.0)
-            != 0) && section.shdr.shtype == elf::types::SHT_PROGBITS
+            != 0)
+            && section.shdr.shtype == elf::types::SHT_PROGBITS
             && section.shdr.size > 0
         {
             if verbose {

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,9 +109,9 @@ build-date = {}",
 /// - Sections in a segment that is RW and set to be loaded will be in RAM and
 ///   should count towards minimum required RAM.
 /// - Sections that are writeable flash regions include .wfr in their name.
-fn elf_to_tbf(
+fn elf_to_tbf<W: Write>(
     input: &elf::File,
-    output: &mut Write,
+    output: &mut W,
     package_name: Option<String>,
     verbose: bool,
     stack_len: u32,

--- a/src/util.rs
+++ b/src/util.rs
@@ -27,7 +27,7 @@ macro_rules! align4needed {
     };
 }
 
-pub fn do_pad(output: &mut io::Write, length: usize) -> io::Result<()> {
+pub fn do_pad<W: io::Write>(output: &mut W, length: usize) -> io::Result<()> {
     let mut pad = length;
     let zero_buf = [0_u8; 512];
     while pad > 0 {


### PR DESCRIPTION
This pull request applies various cleanups:
- `cargo fmt`.
- Fix a few build warnings about missing `dyn` references (refactored to use static dispatch) and unneeded parentheses.
- Various `cargo clippy` warnings (including `write_all` instead of `write` for correctness). Printing is simplified to use `println` and avoid duplicating format arguments.