### PR TITLE
Update to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "elf2tab"
 version = "0.6.0-dev"
+edition = "2018"
 description = "Compiles from ELF to TAB (a Tock Application Bundle using the Tock Binary Format)"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 repository = "https://github.com/tock/elf2tab"

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -2,7 +2,7 @@
 
 use std::path::PathBuf;
 
-use structopt;
+use structopt::StructOpt;
 
 fn usage() -> &'static str {
     "elf2tab [FLAGS] [OPTIONS] ELF...

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,9 +1,10 @@
-use crate::{align4needed, util};
+use crate::util;
 use std::fmt;
 use std::io;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::mem;
 use std::vec;
+use util::amount_alignment_needed;
 
 #[repr(u16)]
 #[derive(Clone, Copy, Debug)]
@@ -147,10 +148,10 @@ impl TbfHeader {
             // Header increases by the TLV and name length.
             header_length += mem::size_of::<TbfHeaderTlv>() + package_name.len();
             // How much padding is needed to ensure we are aligned to 4?
-            let pad = align4needed!(header_length);
+            let pad = amount_alignment_needed(header_length as u32, 4);
             // Header length increases by that padding
-            header_length += pad;
-            pad
+            header_length += pad as usize;
+            pad as usize
         } else {
             0
         };
@@ -242,7 +243,10 @@ impl TbfHeader {
         }
 
         let current_length = header_buf.get_ref().len();
-        util::do_pad(&mut header_buf, align4needed!(current_length))?;
+        util::do_pad(
+            &mut header_buf,
+            amount_alignment_needed(current_length as u32, 4) as usize,
+        )?;
 
         self.inject_checksum(header_buf)
     }

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,9 +1,9 @@
+use crate::{align4needed, util};
 use std::fmt;
 use std::io;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::mem;
 use std::vec;
-use util;
 
 #[repr(u16)]
 #[derive(Clone, Copy, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,24 +1,18 @@
-extern crate chrono;
-extern crate elf;
-extern crate tar;
-#[macro_use]
-extern crate structopt;
-
+use cmdline::Opt;
 use std::cmp;
 use std::fmt::Write as fmtwrite;
 use std::fs;
 use std::io;
 use std::io::{Seek, Write};
 use std::mem;
-
-#[macro_use]
-mod util;
-mod cmdline;
-mod header;
 use structopt::StructOpt;
 
+mod cmdline;
+mod header;
+mod util;
+
 fn main() {
-    let opt = cmdline::Opt::from_args();
+    let opt = Opt::from_args();
 
     let package_name = opt
         .package_name

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use cmdline::Opt;
 use std::cmp;
 use std::fmt::Write as fmtwrite;
 use std::fs;
@@ -13,7 +12,7 @@ mod header;
 mod util;
 
 fn main() {
-    let opt = Opt::from_args();
+    let opt = cmdline::Opt::from_args();
 
     let package_name = opt
         .package_name

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::io;
 use std::io::{Seek, Write};
 use std::mem;
 use structopt::StructOpt;
+use util::{align_to, amount_alignment_needed};
 
 mod cmdline;
 mod header;
@@ -146,7 +147,8 @@ fn elf_to_tbf<W: Write>(
 
     // Add in room the app is asking us to reserve for the stack and heaps to
     // the minimum required RAM size.
-    minimum_ram_size += align8!(stack_len) + align4!(app_heap_len) + align4!(kernel_heap_len);
+    minimum_ram_size +=
+        align_to(stack_len, 8) + align_to(app_heap_len, 4) + align_to(kernel_heap_len, 4);
 
     // Need an array of sections to look for relocation data to include.
     let mut rel_sections: Vec<String> = Vec::new();
@@ -266,7 +268,7 @@ fn elf_to_tbf<W: Write>(
                     section.data.len(),
                 );
             }
-            if align4needed!(binary_index) != 0 {
+            if amount_alignment_needed(binary_index as u32, 4) != 0 {
                 println!(
                     "Warning! Placing section {} at {:#x}, which is not 4-byte aligned.",
                     section.shdr.name, binary_index
@@ -320,7 +322,7 @@ fn elf_to_tbf<W: Write>(
                 rel_data.len(),
             );
         }
-        if !rel_data.is_empty() && align4needed!(binary_index) != 0 {
+        if !rel_data.is_empty() && amount_alignment_needed(binary_index as u32, 4) != 0 {
             println!(
                 "Warning! Placing section {} at {:#x}, which is not 4-byte aligned.",
                 name, binary_index


### PR DESCRIPTION
# Summary

This PR updates elf2tab to the 2018 edition. Only the imports have been amended to match new "path clarity" changes.