### PR TITLE
Add support for Fixed Addresses TLV

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -1,6 +1,5 @@
 //! Command line parser setup for elf2tab.
 
-use std::num::ParseIntError;
 use std::path::PathBuf;
 
 use structopt;
@@ -8,15 +7,6 @@ use structopt;
 fn usage() -> &'static str {
     "elf2tab [FLAGS] [OPTIONS] ELF...
 Converts Tock userspace programs from .elf files to Tock Application Bundles."
-}
-
-fn parse_hex(src: &str) -> Result<u32, ParseIntError> {
-    let without_prefix = src.trim_start_matches("0x");
-    if without_prefix == src {
-        u32::from_str_radix(without_prefix, 10)
-    } else {
-        u32::from_str_radix(without_prefix, 16)
-    }
 }
 
 #[derive(StructOpt, Debug)]
@@ -98,22 +88,6 @@ pub struct Opt {
         help = "Size of the protected region (including headers)"
     )]
     pub protected_region_size: Option<u32>,
-
-    #[structopt(
-        long = "fixed-address-ram",
-        name = "fixed-address-ram",
-        help = "Address in RAM app requires.",
-        parse(try_from_str=parse_hex)
-    )]
-    pub fixed_address_ram: Option<u32>,
-
-    #[structopt(
-        long = "fixed-address-flash",
-        name = "fixed-address-flash",
-        help = "Address in flash app requires.",
-        parse(try_from_str=parse_hex)
-    )]
-    pub fixed_address_flash: Option<u32>,
 }
 
 mod test {
@@ -301,57 +275,6 @@ mod test {
             ];
             let result = Opt::from_iter_safe(args.iter());
             assert!(result.is_ok());
-        }
-    }
-
-    #[test]
-    fn fixed_addresses_succeed() {
-        {
-            let args = vec!["elf2tab", "--fixed-address-ram", "0x20005000", "app.elf"];
-            let result = Opt::from_iter_safe(args.iter());
-            assert!(result.is_ok());
-            let opt = result.unwrap();
-            assert!(opt.fixed_address_ram == Some(0x20005000));
-            assert!(opt.fixed_address_flash == None);
-        }
-        {
-            let args = vec!["elf2tab", "--fixed-address-flash", "0x00005000", "app.elf"];
-            let result = Opt::from_iter_safe(args.iter());
-            assert!(result.is_ok());
-            let opt = result.unwrap();
-            assert!(opt.fixed_address_flash == Some(0x00005000));
-            assert!(opt.fixed_address_ram == None);
-        }
-        {
-            let args = vec!["elf2tab", "--fixed-address-flash", "900", "app.elf"];
-            let result = Opt::from_iter_safe(args.iter());
-            assert!(result.is_ok());
-            let opt = result.unwrap();
-            assert!(opt.fixed_address_flash == Some(900));
-            assert!(opt.fixed_address_ram == None);
-        }
-        {
-            let args = vec!["elf2tab", "--fixed-address-ram", "4000", "app.elf"];
-            let result = Opt::from_iter_safe(args.iter());
-            assert!(result.is_ok());
-            let opt = result.unwrap();
-            assert!(opt.fixed_address_ram == Some(4000));
-            assert!(opt.fixed_address_flash == None);
-        }
-        {
-            let args = vec![
-                "elf2tab",
-                "--fixed-address-ram",
-                "0x20004000",
-                "--fixed-address-flash",
-                "0x30000",
-                "app.elf",
-            ];
-            let result = Opt::from_iter_safe(args.iter());
-            assert!(result.is_ok());
-            let opt = result.unwrap();
-            assert!(opt.fixed_address_ram == Some(0x20004000));
-            assert!(opt.fixed_address_flash == Some(0x30000));
         }
     }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -13,6 +13,7 @@ enum TbfHeaderTypes {
     WriteableFlashRegions = 2,
     PackageName = 3,
     PicOption1 = 4,
+    FixedAddresses = 5,
 }
 
 #[repr(C)]
@@ -47,6 +48,14 @@ struct TbfHeaderWriteableFlashRegion {
     base: TbfHeaderTlv,
     offset: u32,
     size: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+struct TbfHeaderFixedAddresses {
+    base: TbfHeaderTlv,
+    start_process_ram: u32,
+    start_process_flash: u32,
 }
 
 impl fmt::Display for TbfHeaderBase {
@@ -89,11 +98,24 @@ impl fmt::Display for TbfHeaderWriteableFlashRegion {
     }
 }
 
+impl fmt::Display for TbfHeaderFixedAddresses {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(
+            f,
+            "
+     start_process_ram: {0:>8} {0:>#10X}
+   start_process_flash: {1:>8} {1:>#10X}",
+            self.start_process_ram, self.start_process_flash,
+        )
+    }
+}
+
 pub struct TbfHeader {
     hdr_base: TbfHeaderBase,
     hdr_main: TbfHeaderMain,
     hdr_pkg_name_tlv: Option<TbfHeaderTlv>,
     hdr_wfr: Vec<TbfHeaderWriteableFlashRegion>,
+    hdr_fixed_addresses: Option<TbfHeaderFixedAddresses>,
     package_name: String,
     package_name_pad: usize,
 }
@@ -120,6 +142,7 @@ impl TbfHeader {
             },
             hdr_pkg_name_tlv: None,
             hdr_wfr: Vec::new(),
+            hdr_fixed_addresses: None,
             package_name: String::new(),
             package_name_pad: 0,
         }
@@ -137,6 +160,8 @@ impl TbfHeader {
         minimum_ram_size: u32,
         writeable_flash_regions: usize,
         package_name: String,
+        fixed_address_ram: Option<u32>,
+        fixed_address_flash: Option<u32>,
     ) -> usize {
         // Need to calculate lengths ahead of time.
         // Need the base and the main section.
@@ -157,6 +182,13 @@ impl TbfHeader {
 
         // Add room for the writeable flash regions header TLV.
         header_length += mem::size_of::<TbfHeaderWriteableFlashRegion>() * writeable_flash_regions;
+
+        // Check if we are going to include the fixed address header. If so, we
+        // need to make sure we include it in the length. If either address is
+        // set we need to include the entire header.
+        if fixed_address_ram.is_some() || fixed_address_flash.is_some() {
+            header_length += mem::size_of::<TbfHeaderFixedAddresses>();
+        }
 
         // Flags default to app is enabled.
         let flags = 0x0000_0001;
@@ -184,6 +216,18 @@ impl TbfHeader {
                 },
                 offset: 0,
                 size: 0,
+            });
+        }
+
+        // If at least one RAM of flash address is fixed, include the header.
+        if fixed_address_ram.is_some() || fixed_address_flash.is_some() {
+            self.hdr_fixed_addresses = Some(TbfHeaderFixedAddresses {
+                base: TbfHeaderTlv {
+                    tipe: TbfHeaderTypes::FixedAddresses,
+                    length: 8,
+                },
+                start_process_ram: fixed_address_ram.unwrap_or(0xFFFFFFFF),
+                start_process_flash: fixed_address_flash.unwrap_or(0xFFFFFFFF),
             });
         }
 
@@ -239,6 +283,11 @@ impl TbfHeader {
         // Put all writeable flash region header elements in.
         for wfr in &self.hdr_wfr {
             header_buf.write_all(unsafe { util::as_byte_slice(wfr) })?;
+        }
+
+        // If there are fixed addresses, include that TLV.
+        if self.hdr_fixed_addresses.is_some() {
+            header_buf.write_all(unsafe { util::as_byte_slice(&self.hdr_fixed_addresses) })?;
         }
 
         let current_length = header_buf.get_ref().len();

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,8 @@ fn main() {
             opt.app_heap_size,
             opt.kernel_heap_size,
             opt.protected_region_size,
+            opt.fixed_address_ram,
+            opt.fixed_address_flash,
         )
         .unwrap();
 
@@ -119,6 +121,8 @@ fn elf_to_tbf<W: Write>(
     app_heap_len: u32,
     kernel_heap_len: u32,
     protected_region_size_arg: Option<u32>,
+    fixed_address_ram: Option<u32>,
+    fixed_address_flash: Option<u32>,
 ) -> io::Result<()> {
     let package_name = package_name.unwrap_or_default();
 
@@ -193,6 +197,8 @@ fn elf_to_tbf<W: Write>(
         minimum_ram_size,
         writeable_flash_regions_count,
         package_name,
+        fixed_address_ram,
+        fixed_address_flash,
     );
     // If a protected region size was passed, confirm the header will fit.
     // Otherwise, use the header size as the protected region size.


### PR DESCRIPTION
This adds support for the new TLV that allows for specifying where in ram and flash the app needs be. The addresses are inferred from the ELF. If the addresses are flash=0x80000000 and ram=0x00000000 then we assume the app supports PIC and we omit the fixed address TLV. If the addresses are different, then we add the header.