### PR TITLE
Improve how elf2tab parses ELF files

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ elf2tab will also automatically add a TBF "fixed addresses" TLV header if it
 finds that the .elf file was compiled for a fixed address in RAM or flash
 instead of being position independent. To detect a fixed flash address, elf2tab
 looks to see if the flash segment is at the dummy flash address for PIC apps or
-not. To detect a fixed RAM address, elf2tab looks for a `_SRAM_ORIGIN` symbol,
+not. To detect a fixed RAM address, elf2tab looks for a `_sram_origin` symbol,
 and checks if the address matches the dummy RAM address for PIC apps or not.
 
 
@@ -127,5 +127,4 @@ Inspecting TABs
 Tockloader can show some details of a .tab file. Simply:
 
     $ tockloader inspect-tab <tab file name>
-
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ writeable flash regions, the name of the section should include the string
 their relative address offset included in the TBF header via the
 `TbfHeaderWriteableFlashRegions` TLV.
 
+elf2tab will also automatically add a TBF "fixed addresses" TLV header if it
+finds that the .elf file was compiled for a fixed address in RAM or flash
+instead of being position independent. To detect a fixed flash address, elf2tab
+looks to see if the flash segment is at the dummy flash address for PIC apps or
+not. To detect a fixed RAM address, elf2tab looks for a `_SRAM_ORIGIN` symbol,
+and checks if the address matches the dummy RAM address for PIC apps or not.
+
+
 ### Creating the TAB file
 
 After generating the program binary and TBF header for each .elf file specified

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ finds that the .elf file was compiled for a fixed address in RAM or flash
 instead of being position independent. To detect a fixed flash address, elf2tab
 looks to see if the flash segment is at the dummy flash address for PIC apps or
 not. To detect a fixed RAM address, elf2tab looks for a `_sram_origin` symbol,
-and checks if the address matches the dummy RAM address for PIC apps or not.
+and if it exists checks if the address matches the dummy RAM address for PIC
+apps or not.
 
 
 ### Creating the TAB file
@@ -127,4 +128,3 @@ Inspecting TABs
 Tockloader can show some details of a .tab file. Simply:
 
     $ tockloader inspect-tab <tab file name>
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,7 +176,7 @@ fn elf_to_tbf<W: Write>(
     // reliably extracting it from different ELFs linked with different
     // toolchains from different linker scripts would I think require resorting
     // to a bit of heuristics and guessing. To avoid the potential issues there,
-    // we instead require that a `_SRAM_ORIGIN` symbol be present to explicitly
+    // we instead require that a `_sram_origin` symbol be present to explicitly
     // mark the start of RAM.
     //
     // In both cases we check to see if the address matches our expected PIC
@@ -258,10 +258,10 @@ fn elf_to_tbf<W: Write>(
     section_symtab.map(|s_symtab| {
         let symbols = input.get_symbols(s_symtab);
         symbols.ok().map(|syms| {
-            // We are looking for the `_SRAM_ORIGIN` symbol and its value.
+            // We are looking for the `_sram_origin` symbol and its value.
             // If it exists, we try to use it. Otherwise, we just do not try
             // to find a fixed RAM address.
-            let sram_origin_symbol = syms.iter().find(|sy| sy.name == "_SRAM_ORIGIN");
+            let sram_origin_symbol = syms.iter().find(|sy| sy.name == "_sram_origin");
             sram_origin_symbol.map(|sram_origin| {
                 let sram_origin_address = sram_origin.value as u32;
                 // If address does not match our dummy address for PIC, then we


### PR DESCRIPTION
This fixes two things:

1. Calculating how much RAM the app needs based on the ELF sections. Before we stopped after finding any segment that is destined for RAM. This doesn't work for libtock-c now that .stack is its own section. So not only do we consider multiple segments if necessary, but the checking for if it should count towards the amount of RAM required is more robust.
2. Finding fixed addresses. The fixed address in flash is mostly the same, made a little more robust for libtock-rs. RAM however won't work the same way since libtock-rs doesn't generate any segments at the correct address in RAM. Therefore, we use a special symbol the linker file has to specify.