### PR TITLE
Estimate a protected region size for fixed address apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,19 @@ not. To detect a fixed RAM address, elf2tab looks for a `_sram_origin` symbol,
 and if it exists checks if the address matches the dummy RAM address for PIC
 apps or not.
 
+elf2tab has to choose a length for the protected region after the TBF header and
+before the start of the actual application binary. Normally, this defaults to 0.
+It can be fixed for all TBFs in the TAB using the command line argument
+`--protected-region-size` (which takes as an argument entire size before the
+application binary, including the TBF header). However, a TAB can include both
+PIC apps and non-PIC apps, and setting the size for all TBFs isn't always
+desirable. Therefore, if `--protected-region-size` is not used, for apps
+compiled for fixed addresses (as determined above) elf2tab will estimate a
+protected region size that tries to ensure the start of the TBF headers _and_
+the application binary are placed at useful addresses in flash. elf2tab will try
+to increase the size of the protected region to make the start of the TBF header
+at an address aligned to 256 bytes when the application binary is at its correct
+fixed address.
 
 ### Creating the TAB file
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -346,6 +346,8 @@ impl fmt::Display for TbfHeader {
         for wfr in &self.hdr_wfr {
             write!(f, "{}", wfr)?;
         }
+        self.hdr_fixed_addresses
+            .map_or(Ok(()), |hdr| write!(f, "{}", hdr))?;
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,9 @@ fn main() {
             .unwrap();
 
         // Do the conversion to a tock binary.
+        if opt.verbose {
+            println!("Creating {:?}", tbf_path);
+        }
         elf_to_tbf(
             &elffile,
             &mut outfile,
@@ -79,6 +82,9 @@ fn main() {
             opt.protected_region_size,
         )
         .unwrap();
+        if opt.verbose {
+            println!("");
+        }
 
         // Add the file to the TAB tar file.
         outfile.seek(io::SeekFrom::Start(0)).unwrap();

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,6 +8,11 @@ pub fn align_to(value: u32, box_size: u32) -> u32 {
     value + ((box_size - (value % box_size)) % box_size)
 }
 
+/// Takes a value and rounds it down to be aligned % box_size
+pub fn align_down(value: u32, box_size: u32) -> u32 {
+    value - (value % box_size)
+}
+
 /// How much needs to be added to get a value aligned % 4
 pub fn amount_alignment_needed(value: u32, box_size: u32) -> u32 {
     align_to(value, box_size) - value


### PR DESCRIPTION
Part of the difficulty of using fixed address apps is that the start of the TBF also has to fall at a certain address so the kernel can find the app. We worked around this issue with the `--protected-region-size` argument to elf2tab so that the tbf start can be set to a fixed offset before the application binary. The downside is this applies to all apps being inserted into the TAB, even if they are PIC.

This PR lets elf2tab estimate a reasonable length for the offset of the application binary in the TBF file, if the TBF is compiled for a fixed address in flash. This makes the raw TBF binary a little easier to use, as in most cases it can be directly flashed to the board. elf2tab has no way of actually knowing where the TBF will be placed, and how large the protected region should be, so this is only a guess. Tockloader will be able to handle the other cases by dynamically expanding the protected region size once it knows all of the relevant addresses when flashing the application.