### PR TITLE
Add flags to TAB metadata.toml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ OPTIONS:
         --read_ids <read_ids>...                           Storage IDs that this app is allowed to read
         --stack <stack-size>                               in bytes [default: 2048]
         --write_id <write_id>                              A storage ID used for writing data
+        --supported-boards <supported-boards>              Comma separated list of boards this app is compatible with
 
 ARGS:
     <elf[,architecture]>...    application file(s) to package

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -172,6 +172,13 @@ pub struct Opt {
         help = "The minimum kernel minor version that the app requires"
     )]
     pub kernel_minor: Option<u16>,
+
+    #[structopt(
+        long = "supported-boards",
+        name = "supported-boards",
+        help = "comma separated list of boards this app is compatible with"
+    )]
+    pub supported_boards: Option<String>,
 }
 
 mod test {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use elf2tab::convert;
 fn main() {
     let opt = cmdline::Opt::from_args();
 
+    // Get app name from command line arguments or use empty string as default.
     let package_name = opt
         .package_name
         .as_ref()
@@ -31,8 +32,6 @@ fn main() {
     writeln!(&mut metadata_toml, "tab-version = 1").unwrap();
     // Name is always set by elf2tab (even if it is empty).
     writeln!(&mut metadata_toml, "name = \"{}\"", package_name).unwrap();
-    // We don't currently tell elf2tab if this app only runs on certain boards.
-    writeln!(&mut metadata_toml, "only-for-boards = \"\"").unwrap();
     // Include "minimum-tock-kernel-version" key if a necessary kernel version
     // was specified.
     minimum_tock_kernel_version.map(|(major, minor)| {
@@ -40,6 +39,15 @@ fn main() {
             &mut metadata_toml,
             "minimum-tock-kernel-version = \"{}.{}\"",
             major, minor
+        )
+        .unwrap();
+    });
+    // Include "only-for-boards" key if specific boards were specified.
+    opt.supported_boards.as_ref().map(|supported_boards| {
+        writeln!(
+            &mut metadata_toml,
+            "only-for-boards = \"{}\"",
+            supported_boards.as_str()
         )
         .unwrap();
     });


### PR DESCRIPTION
This PR updates the metadata.toml file that elf2tab generates. Specifically:

- It adds a command line flag `--supported-boards` so that apps can specify which boards they are compatible with (if there happens to be a particular restriction). For example `--supported-boards hail,imix` would then add that information to the metadata file in the TAB, and then tockloader can check and give an error to the user if they try to install that app on a board not named hail or imix.

- ~~It adds a second command line flag `--tock-kernel-version`. Again this adds an entry to the metadata file, so that an app can specify which kernel ABI version it requires and tockloader can help check. My intention is that a 2.0-compliant userspace would add `elf2tab ... --tock-kernel-version 2` to its build system.~~