### PR TITLE
No longer include .bin files in TAB

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -116,12 +116,6 @@ fn main() {
         outfile.seek(io::SeekFrom::Start(0)).unwrap();
         tab.append_file(tbf_path.file_name().unwrap(), &mut outfile)
             .unwrap();
-        outfile.seek(io::SeekFrom::Start(0)).unwrap();
-        tab.append_file(
-            tbf_path.with_extension("bin").file_name().unwrap(),
-            &mut outfile,
-        )
-        .unwrap();
     }
 }
 


### PR DESCRIPTION
This was left in for backwards compatibility with (really) old versions of tockloader that expected .bin files (instead of .tbf files). There cannot be anyone still using tockloader that old, and around 2.0 seems like the time to remove this old hack.