### PR TITLE
Make binary padding to power of two optional, only use for cortex-m

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,17 @@ fn main() {
             .open(tbf_path.clone())
             .unwrap();
 
+        // Adding padding to the end of cortex-m apps. Check for a cortex-m app
+        // because the start of the elf filename will start with "cortex".
+        //
+        // RISC-V apps do not need to be sized to power of two.
+        let add_trailing_padding = elf_path
+            .file_name()
+            .unwrap_or(std::ffi::OsStr::new(""))
+            .to_str()
+            .unwrap_or("")
+            .starts_with("cortex");
+
         // Do the conversion to a tock binary.
         if opt.verbose {
             println!("Creating {:?}", tbf_path);
@@ -106,7 +117,7 @@ fn main() {
             opt.protected_region_size,
             opt.permissions.to_vec(),
             minimum_tock_kernel_version,
-            true,
+            add_trailing_padding,
         )
         .unwrap();
         if opt.verbose {

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,15 +92,12 @@ fn main() {
             .unwrap();
 
         // Adding padding to the end of cortex-m apps. Check for a cortex-m app
-        // because the start of the elf filename will start with "cortex".
+        // by inspecting the "machine" value in the elf header. 0x28 is ARM (see
+        // https://en.wikipedia.org/wiki/Executable_and_Linkable_Format#File_header
+        // for a list).
         //
         // RISC-V apps do not need to be sized to power of two.
-        let add_trailing_padding = elf_path
-            .file_name()
-            .unwrap_or(std::ffi::OsStr::new(""))
-            .to_str()
-            .unwrap_or("")
-            .starts_with("cortex");
+        let add_trailing_padding = elffile.ehdr.machine.0 == 0x28;
 
         // Do the conversion to a tock binary.
         if opt.verbose {

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,7 @@ fn main() {
             opt.protected_region_size,
             opt.permissions.to_vec(),
             minimum_tock_kernel_version,
+            true,
         )
         .unwrap();
         if opt.verbose {
@@ -148,6 +149,7 @@ fn elf_to_tbf<W: Write>(
     protected_region_size_arg: Option<u32>,
     permissions: Vec<(u32, u32)>,
     kernel_version: Option<(u16, u16)>,
+    trailing_padding: bool,
 ) -> io::Result<()> {
     let package_name = package_name.unwrap_or_default();
 
@@ -553,16 +555,25 @@ fn elf_to_tbf<W: Write>(
     // the relocation data length.
     binary_index += relocation_binary.len() + mem::size_of::<u32>();
 
-    // That is everything that we are going to include in our app binary. Now
-    // we need to pad the binary to a power of 2 in size, and make sure it is
-    // at least 512 bytes in size.
-    let post_content_pad = if binary_index.count_ones() > 1 {
-        let power2len = cmp::max(1 << (32 - (binary_index as u32).leading_zeros()), 512);
-        power2len - binary_index
+    // That is everything that we are going to include in our app binary.
+
+    let post_content_pad = if trailing_padding {
+        // If trailing padding is requested, we need to pad the binary to a
+        // power of 2 in size, and make sure it is at least 512 bytes in size.
+        let pad = if binary_index.count_ones() > 1 {
+            let power2len = cmp::max(1 << (32 - (binary_index as u32).leading_zeros()), 512);
+            power2len - binary_index
+        } else {
+            0
+        };
+        // Increment to include the padding.
+        binary_index += pad;
+        pad
     } else {
+        // No padding.
         0
     };
-    binary_index += post_content_pad;
+
     let total_size = binary_index;
 
     // Now set the total size of the app in the header.
@@ -580,7 +591,7 @@ fn elf_to_tbf<W: Write>(
     output.write_all(&rel_data_len)?;
     output.write_all(relocation_binary.as_ref())?;
 
-    // Pad to get a power of 2 sized flash app.
+    // Pad to get a power of 2 sized flash app, if requested.
     util::do_pad(output, post_content_pad as usize)?;
 
     Ok(())


### PR DESCRIPTION
elf2tab was originally written for only cortex-m apps, and since those have always needed to be padded to a power of two, the functionality to add the padding has always been baked in. Nowadays, not all apps need to be padded (RISC-V boards do not have the same requirement), and we don't necessarily want to force long apps in all cases.

This changes elf2tab to only pad cortex-m apps.

We _could_ not pad any apps, and leave the padding up to tockloader. Tockloader can handle this just fine. However, that would make it difficult to manually flash .tbf files to cortex-m boards without tockloader, so it is probably better to have both elf2tab and tockloader support the padding.