### PR TITLE
Add support for persistent access controls IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,31 +11,29 @@ Usage
 
 ```
 USAGE:
-    elf2tab [FLAGS] [--protected-region-size=<protected-region-size>]
-                    [--package-name=<pkg-name>] [--output-file=<filename>] <elf>...
-    elf2tab [FLAGS] [--protected-region-size=<protected-region-size>] [--package-name=<pkg-name>]
-                    [--output-file=<filename>] [--minimum-ram-size=<min-ram-size>] <elf>...
-    elf2tab [FLAGS] [--protected-region-size=<protected-region-size>]
-                    [--package-name=<pkg-name>] [--output-file=<filename>]
-                    [--app-heap=<heap-size>] [--kernel-heap=<kernel-heap-size>] [--stack=<stack-size>] <elf>...
+    elf2tab [FLAGS] [OPTIONS] ELF...
+Converts Tock userspace programs from .elf files to Tock Application Bundles.
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-    -v, --verbose    Be verbose
+        --deterministic    Produce a deterministic TAB file
+    -h, --help             Prints help information
+    -V, --version          Prints version information
+    -v, --verbose          Be verbose
 
 OPTIONS:
-        --deterministic                         Produce a deterministic TAB file
-    -o, --output-file <filename>                Output file name [default: TockApp.tab]
-    -n, --package-name <pkg-name>               Package name [default: empty]
-        --protected-region-size <protected-region-size>
-                                                Size of the protected region (including headers)
-        --minimum-ram-size <min-ram-size>       In bytes [default: from RAM sections in ELF]
-        --app-heap <heap-size>                  In bytes [default: 1024]
-        --kernel-heap <kernel-heap-size>        In bytes [default: 1024]
-        --stack <stack-size>                    In bytes [default: 2048]
-        --kernel-major <kernel-major-version>   The kernel version that the app requires
-        --kernel-minor <kernel-minor-version>   The minimum kernel minor version that the app requires
+        --access_ids <access_ids>...                       Storage IDs that this app is allowed to write
+    -o, --output-file <filename>                           output file name [default: TockApp.tab]
+        --app-heap <heap-size>                             in bytes [default: 1024]
+        --kernel-heap <kernel-heap-size>                   in bytes [default: 1024]
+        --kernel-major <kernel-major-version>              The kernel version that the app requires
+        --kernel-minor <kernel-minor-version>              The minimum kernel minor version that the app requires
+        --minimum-ram-size <min-ram-size>                  in bytes
+        --permissions <permissions>...                     A list of driver numbers and allowed commands
+    -n, --package-name <pkg-name>                          package name
+        --protected-region-size <protected-region-size>    Size of the protected region (including headers)
+        --read_ids <read_ids>...                           Storage IDs that this app is allowed to read
+        --stack <stack-size>                               in bytes [default: 2048]
+        --write_id <write_id>                              A storage ID used for writing data
 
 ARGS:
     <elf>...    application file(s) to package
@@ -46,7 +44,7 @@ device) with this tool would look like:
 
     $ elf2tab -o blink.tab -n blink --stack 1024 --app-heap 1024 --kernel-heap 1024 cortex-m4.elf
 
-It also supports (and encourages!) combing .elf files for multiple architectures
+It also supports (and encourages!) combining .elf files for multiple architectures
 into a single tab:
 
     $ elf2tab -o blink.tab -n blink --stack 1024 --app-heap 1024 --kernel-heap 1024 cortex-m0.elf cortex-m3.elf cortex-m4.elf
@@ -126,6 +124,27 @@ the application binary are placed at useful addresses in flash. elf2tab will try
 to increase the size of the protected region to make the start of the TBF header
 at an address aligned to 256 bytes when the application binary is at its correct
 fixed address.
+
+#### Syscall Permissions
+
+elf2tab allows explicitly specifying the syscalls that an app is allowed to
+call. This is done with the `--permissions` flag.
+An example of allowing driver number `1` command `0` and command `1` looks like
+this:
+
+    $ elf2tab --permissions 1,0 1,1 ...
+
+It is then up to the Tock kernel and board to apply the filters.
+
+#### Storage IDs
+
+elf2tab also allows specifying the storage IDs. These are used to access
+nonvolatile data from userspace. You can specify a single write_id used
+to store new data and multiple read_ids and access_ids used to enforce
+read/write permissions on existing data.
+
+An example looks like this
+    $ elf2tab  --write_id 12345678 --read_ids 1 2 --access_ids 2 3 ...
 
 ### Creating the TAB file
 

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -111,6 +111,27 @@ pub struct Opt {
     pub permissions: Vec<(u32, u32)>,
 
     #[structopt(
+        long = "write_id",
+        name = "write_id",
+        help = "A storage ID used for writing data"
+    )]
+    pub write_id: Option<u32>,
+
+    #[structopt(
+        long = "read_ids",
+        name = "read_ids",
+        help = "Storage IDs that this app is allowed to read"
+    )]
+    pub read_ids: Option<Vec<u32>>,
+
+    #[structopt(
+        long = "access_ids",
+        name = "access_ids",
+        help = "Storage IDs that this app is allowed to write"
+    )]
+    pub access_ids: Option<Vec<u32>>,
+
+    #[structopt(
         long = "kernel-major",
         name = "kernel-major-version",
         help = "The kernel version that the app requires"
@@ -355,6 +376,26 @@ mod test {
                 "10",
                 "--minimum-ram-size",
                 "10",
+                "app.elf",
+            ];
+            let result = Opt::from_iter_safe(args.iter());
+            assert!(result.is_err());
+        }
+    }
+
+    #[test]
+    // elf2tab [FLAGS] [--write_id=<write_id>] [--read_ids=<read_ids>] [--access_ids=<access_ids>]
+    //                <elf>..."
+    fn storage_ids() {
+        {
+            let args = vec![
+                "elf2tab",
+                "--write_id",
+                "1234567",
+                "--read_ids",
+                "1 2",
+                "--access_ids",
+                "2 3",
                 "app.elf",
             ];
             let result = Opt::from_iter_safe(args.iter());

--- a/src/header.rs
+++ b/src/header.rs
@@ -73,7 +73,7 @@ struct TbfHeaderDriverPermission {
 #[derive(Debug)]
 struct TbfHeaderPermissions {
     base: TbfHeaderTlv,
-    array_length: u16,
+    length: u16,
     perms: Vec<TbfHeaderDriverPermission>,
 }
 
@@ -142,9 +142,9 @@ impl fmt::Display for TbfHeaderPermissions {
         writeln!(
             f,
             "
-          array_length: {0:>8} {0:>#8}
+    driver permissions: {0:>8}
            permissions:   Number   Offset  Allowed Bit Mask",
-            self.array_length,
+            self.length,
         )?;
 
         for perm in &self.perms {
@@ -328,9 +328,9 @@ impl TbfHeader {
             self.hdr_permissions = Some(TbfHeaderPermissions {
                 base: TbfHeaderTlv {
                     tipe: TbfHeaderTypes::Permissions,
-                    length: 8,
+                    length: (perms.len() * mem::size_of::<TbfHeaderDriverPermission>()) as u16 + 2,
                 },
-                array_length: perms.len() as u16,
+                length: perms.len() as u16,
                 perms,
             });
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,7 @@ fn main() {
             opt.kernel_heap_size,
             opt.protected_region_size,
             opt.permissions.to_vec(),
+            (opt.write_id, opt.read_ids.clone(), opt.access_ids.clone()),
             minimum_tock_kernel_version,
             add_trailing_padding,
         )
@@ -150,6 +151,7 @@ fn elf_to_tbf<W: Write>(
     kernel_heap_len: u32,
     protected_region_size_arg: Option<u32>,
     permissions: Vec<(u32, u32)>,
+    storage_ids: (Option<u32>, Option<Vec<u32>>, Option<Vec<u32>>),
     kernel_version: Option<(u16, u16)>,
     trailing_padding: bool,
 ) -> io::Result<()> {
@@ -359,6 +361,7 @@ fn elf_to_tbf<W: Write>(
         fixed_address_ram,
         fixed_address_flash,
         permissions,
+        storage_ids,
         kernel_version,
     );
     // If a protected region size was passed, confirm the header will fit.


### PR DESCRIPTION
This builds on https://github.com/tock/elf2tab/pull/28 by also allowing storage permissions to be specified.

An example of what this would look like (with driver permissions as well) is:

```
elf2tab --permissions 1,1 1,2 2,2 --write_id 12345678 --read_ids 1 2 --access_ids 2 3 -v <elf>
```

and the output looks like:

```
TBF Header:
               version:        2        0x2
           header_size:       44       0x2C
            total_size:     1248      0x4E0
                 flags:        1        0x1

        init_fn_offset:      124       0x7C
        protected_size:       84       0x54
      minimum_ram_size:     4572     0x11DC

     start_process_ram: 268455936 0x10005000
   start_process_flash: 537067648 0x20030080

    driver permissions:        2
           permissions:   Number   Offset  Allowed Bit Mask
                      :      0x1        0               0x6
                      :      0x2        0               0x4

              write ID:            0xBC614E
              read IDs:        2
                      :                 0x1
                      :                 0x2
            access IDs:        2
                      :                 0x2
                      :                 0x3
```