### PR TITLE
Allow creating disabled apps (TBF disabled flag set)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Converts Tock userspace programs from .elf files to Tock Application Bundles.
 
 FLAGS:
         --deterministic    Produce a deterministic TAB file
+        --disable          Mark the app as disabled in the TBF flags
     -h, --help             Prints help information
     -V, --version          Prints version information
     -v, --verbose          Be verbose

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -64,6 +64,9 @@ pub struct Opt {
     #[structopt(long = "deterministic", help = "Produce a deterministic TAB file")]
     pub deterministic: bool,
 
+    #[structopt(long = "disable", help = "Mark the app as disabled in the TBF flags")]
+    pub disabled: bool,
+
     #[structopt(
         long = "minimum-ram-size",
         name = "min-ram-size",

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -92,11 +92,7 @@ pub struct Opt {
     )]
     pub package_name: Option<String>,
 
-    #[structopt(
-        long = "stack",
-        name = "stack-size",
-        help = "in bytes"
-    )]
+    #[structopt(long = "stack", name = "stack-size", help = "in bytes")]
     pub stack_size: Option<u32>,
 
     #[structopt(

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,9 +1,9 @@
+use crate::header;
+use crate::util::{self, align_to, amount_alignment_needed};
 use std::cmp;
 use std::io;
 use std::io::Write;
 use std::mem;
-use crate::util::{self, align_to, amount_alignment_needed};
-use crate::header;
 
 /// Convert an ELF file to a TBF (Tock Binary Format) binary file.
 ///

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -408,9 +408,19 @@ pub fn elf_to_tbf<W: Write>(
                 && input.ehdr.entry < (section.shdr.addr + section.shdr.size)
                 && (section.shdr.name.find("debug")).is_none()
             {
-                // panic in case we detect entry point in multiple sections.
+                // In the normal case, panic in case we detect entry point in
+                // multiple sections.
                 if entry_point_found {
-                    panic!("Duplicate entry point in {} section", section.shdr.name);
+                    // If the app is disabled just report a warning if we find
+                    // two entry points. OTBN apps will contain two entry
+                    // points, so this allows us to load them.
+                    if disabled {
+                        if verbose {
+                            println!("Duplicate entry point in {} section", section.shdr.name);
+                        }
+                    } else {
+                        panic!("Duplicate entry point in {} section", section.shdr.name);
+                    }
                 }
                 entry_point_found = true;
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -30,6 +30,7 @@ pub fn elf_to_tbf<W: Write>(
     storage_ids: (Option<u32>, Option<Vec<u32>>, Option<Vec<u32>>),
     kernel_version: Option<(u16, u16)>,
     trailing_padding: bool,
+    disabled: bool,
 ) -> io::Result<()> {
     let package_name = package_name.unwrap_or_default();
 
@@ -253,6 +254,7 @@ pub fn elf_to_tbf<W: Write>(
         permissions,
         storage_ids,
         kernel_version,
+        disabled,
     );
     // If a protected region size was passed, confirm the header will fit.
     // Otherwise, use the header size as the protected region size.

--- a/src/header.rs
+++ b/src/header.rs
@@ -209,6 +209,8 @@ impl fmt::Display for TbfHeaderKernelVersion {
     }
 }
 
+const FLAGS_ENABLE: u32 = 0x0000_0001;
+
 pub struct TbfHeader {
     hdr_base: TbfHeaderBase,
     hdr_main: TbfHeaderMain,
@@ -270,6 +272,7 @@ impl TbfHeader {
         permissions: Vec<(u32, u32)>,
         storage_ids: (Option<u32>, Option<Vec<u32>>, Option<Vec<u32>>),
         kernel_version: Option<(u16, u16)>,
+        disabled: bool,
     ) -> usize {
         // Need to calculate lengths ahead of time.
         // Need the base and the main section.
@@ -357,8 +360,11 @@ impl TbfHeader {
             header_length += mem::size_of::<TbfHeaderKernelVersion>();
         }
 
-        // Flags default to app is enabled.
-        let flags = 0x0000_0001;
+        let mut flags = 0x0000_0000;
+
+        if !disabled {
+            flags |= FLAGS_ENABLE
+        };
 
         // Fill in the fields that we can at this point.
         self.hdr_base.header_size = header_length as u16;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod cmdline;
+pub mod convert;
 pub mod header;
 pub mod util;
-pub mod convert;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ use std::io;
 use std::io::Seek;
 use structopt::StructOpt;
 
-use elf2tab::convert;
 use elf2tab::cmdline;
+use elf2tab::convert;
 
 fn main() {
     let opt = cmdline::Opt::from_args();

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,7 @@ fn main() {
             (opt.write_id, opt.read_ids.clone(), opt.access_ids.clone()),
             minimum_tock_kernel_version,
             add_trailing_padding,
+            opt.disabled,
         )
         .unwrap();
         if opt.verbose {


### PR DESCRIPTION
This PR allows creating disabled apps that the Tock kernel can then use to program the [OTBN](https://docs.opentitan.org/hw/ip/otbn/doc/index.html#running-applications-on-otbn)