### PR TITLE
Use architecture parameter for elf file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Usage
 
 ```
 USAGE:
-    elf2tab [FLAGS] [OPTIONS] ELF...
+    elf2tab [FLAGS] [OPTIONS] ELF[,ARCHITECTURE]...
 Converts Tock userspace programs from .elf files to Tock Application Bundles.
 
 FLAGS:
@@ -36,7 +36,7 @@ OPTIONS:
         --write_id <write_id>                              A storage ID used for writing data
 
 ARGS:
-    <elf>...    application file(s) to package
+    <elf[,architecture]>...    application file(s) to package
 ```
 
 For example, converting a "blink" app from a compiled .elf file (for a Cortex-M4

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -1,11 +1,12 @@
 //! Command line parser setup for elf2tab.
 
 use std::error::Error;
+use std::ffi::OsStr;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
 fn usage() -> &'static str {
-    "elf2tab [FLAGS] [OPTIONS] ELF...
+    "elf2tab [FLAGS] [OPTIONS] ELF[,ARCHITECTURE]...
 Converts Tock userspace programs from .elf files to Tock Application Bundles."
 }
 
@@ -20,6 +21,28 @@ where
         .find(',')
         .ok_or_else(|| format!("invalid number,option: no `,` found in `{}`", s))?;
     Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
+}
+
+#[derive(Debug)]
+pub struct ElfFile {
+    pub path: PathBuf,
+    pub architecture: Option<String>,
+}
+
+impl From<&OsStr> for ElfFile {
+    fn from(value: &OsStr) -> Self {
+        let mut elf_file = ElfFile {
+            path: value.into(),
+            architecture: None,
+        };
+        if let Some(s) = value.to_str() {
+            if let Some(index) = s.rfind(',') {
+                elf_file.path = PathBuf::from(&s[0..index]);
+                elf_file.architecture = Some(String::from(&s[index + 1..]));
+            }
+        }
+        elf_file
+    }
 }
 
 #[derive(StructOpt, Debug)]
@@ -88,12 +111,12 @@ pub struct Opt {
     pub kernel_heap_size: u32,
 
     #[structopt(
-        name = "elf",
+        name = "elf[,architecture]",
         help = "application file(s) to package",
         parse(from_os_str),
         required = true
     )]
-    pub input: Vec<PathBuf>,
+    pub input: Vec<ElfFile>,
 
     #[structopt(
         long = "protected-region-size",
@@ -155,7 +178,7 @@ mod test {
     use structopt::StructOpt;
 
     #[test]
-    // elf2tab [FLAGS] [--package-name=<pkg-name>] [--output-file=[<filename>]] <elf>...
+    // elf2tab [FLAGS] [--package-name=<pkg-name>] [--output-file=[<filename>]] <elf[,architecture]>...
     fn simple_invocations_succeed() {
         {
             let args = vec!["elf2tab", "app.elf"];
@@ -193,7 +216,7 @@ mod test {
     }
 
     #[test]
-    // elf2tab [FLAGS] [--package-name=<pkg-name>] [--output-file=[<filename>]] <elf>...
+    // elf2tab [FLAGS] [--package-name=<pkg-name>] [--output-file=[<filename>]] <elf[,architecture]>...
     fn simple_invocations_fail() {
         {
             let args = vec!["elf2tab", "app.elf", "--package-name"];
@@ -220,7 +243,7 @@ mod test {
     }
 
     #[test]
-    // elf2tab [FLAGS] [--package-name=<pkg-name>] [--output-file=[<filename>]] [--minimum-stack-size=<min-stack-size>] <elf>...
+    // elf2tab [FLAGS] [--package-name=<pkg-name>] [--output-file=[<filename>]] [--minimum-stack-size=<min-stack-size>] <elf[,architecture]>...
     fn advanced_invocations_fail() {
         {
             let args = vec![
@@ -279,7 +302,7 @@ mod test {
 
     #[test]
     // elf2tab [FLAGS] [--package-name=<pkg-name>] [--output-file=[<filename>]] [--app-heap[=<heap-size>]]
-    //                [--kernel-heap[=<kernel-heap-size>]] [--stack[=<stack-size>]] <elf>..."
+    //                [--kernel-heap[=<kernel-heap-size>]] [--stack[=<stack-size>]] <elf[,architecture]>..."
     fn expert_invocations_succeed() {
         {
             let args = vec![
@@ -337,7 +360,7 @@ mod test {
 
     #[test]
     // elf2tab [FLAGS] [--package-name=<pkg-name>] [--output-file=[<filename>]] [--app-heap[=<heap-size>]]
-    //                [--kernel-heap[=<kernel-heap-size>]] [--stack[=<stack-size>]] <elf>..."
+    //                [--kernel-heap[=<kernel-heap-size>]] [--stack[=<stack-size>]] <elf[,architecture]>..."
     fn expert_invocations_fail() {
         {
             let args = vec![
@@ -385,7 +408,7 @@ mod test {
 
     #[test]
     // elf2tab [FLAGS] [--write_id=<write_id>] [--read_ids=<read_ids>] [--access_ids=<access_ids>]
-    //                <elf>..."
+    //                <elf[,architecture]>..."
     fn storage_ids() {
         {
             let args = vec![

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -23,9 +23,15 @@ where
     Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
 }
 
+/// Helper struct for keeping track of the ELF files to convert and an optional
+/// architecture string.
 #[derive(Debug)]
 pub struct ElfFile {
+    /// Caller must provide a path to the ELF.
     pub path: PathBuf,
+    /// Callers may optionally include the target architecture for that ELF.
+    /// Otherwise the architecture will be inferred from the name of the ELF
+    /// file.
     pub architecture: Option<String>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,25 +69,7 @@ fn main() {
     // Iterate all input elfs. Convert them to Tock friendly binaries and then
     // add them to the TAB file.
     for elf_file in opt.input {
-        let (tbf_path, architecture) = if let Some(ref architecture) = elf_file.architecture {
-            (
-                elf_file
-                    .path
-                    .with_extension(format!("{}.tbf", architecture)),
-                architecture.clone(),
-            )
-        } else {
-            (
-                elf_file.path.with_extension("tbf"),
-                elf_file
-                    .path
-                    .file_name()
-                    .unwrap()
-                    .to_str()
-                    .unwrap()
-                    .to_string(),
-            )
-        };
+        let tbf_path = elf_file.path.with_extension("tbf");
 
         let elffile = elf::File::open_path(&elf_file.path).expect("Could not open the .elf file.");
 
@@ -142,6 +124,17 @@ fn main() {
 
         // Add the file to the TAB tar file.
         outfile.seek(io::SeekFrom::Start(0)).unwrap();
+        let architecture = if let Some(ref architecture) = elf_file.architecture {
+            architecture.clone()
+        } else {
+            elf_file
+                .path
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string()
+        };
         tab.append_file(format!("{}.tbf", architecture), &mut outfile)
             .unwrap();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,9 +69,32 @@ fn main() {
     // Iterate all input elfs. Convert them to Tock friendly binaries and then
     // add them to the TAB file.
     for elf_file in opt.input {
+        let elffile = elf::File::open_path(&elf_file.path).expect("Could not open the .elf file.");
+
+        // The TBF will be written to the same place as the ELF, with a .tbf
+        // extension.
         let tbf_path = elf_file.path.with_extension("tbf");
 
-        let elffile = elf::File::open_path(&elf_file.path).expect("Could not open the .elf file.");
+        // Get the name of the architecture for the TBF. This will be used to
+        // name the TBF in the TAB, as the file name is expected to be
+        // `<architecture>.tbf`.
+        let architecture = if let Some(ref architecture) = elf_file.architecture {
+            // The caller of elf2tab explicitly told us the architecture via
+            // command line arguments.
+            architecture.clone()
+        } else {
+            // Otherwise, we must assume that the elf was named as
+            // `<architecture>.elf` and use the base name as the architecture.
+            elf_file
+                .path
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string()
+        };
+        // Use the architecture to name the TBF in the TAB.
+        let tab_tbf_name = format!("{}.tbf", architecture);
 
         if opt.output.clone() == tbf_path.clone() {
             panic!(
@@ -124,19 +147,7 @@ fn main() {
 
         // Add the file to the TAB tar file.
         outfile.seek(io::SeekFrom::Start(0)).unwrap();
-        let architecture = if let Some(ref architecture) = elf_file.architecture {
-            architecture.clone()
-        } else {
-            elf_file
-                .path
-                .file_name()
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .to_string()
-        };
-        tab.append_file(format!("{}.tbf", architecture), &mut outfile)
-            .unwrap();
+        tab.append_file(tab_tbf_name, &mut outfile).unwrap();
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,9 @@ fn main() {
     for elf_file in opt.input {
         let (tbf_path, architecture) = if let Some(ref architecture) = elf_file.architecture {
             (
-                elf_file.path.with_extension(format!("{architecture}.tbf")),
+                elf_file
+                    .path
+                    .with_extension(format!("{}.tbf", architecture)),
                 architecture.clone(),
             )
         } else {
@@ -140,7 +142,7 @@ fn main() {
 
         // Add the file to the TAB tar file.
         outfile.seek(io::SeekFrom::Start(0)).unwrap();
-        tab.append_file(format!("{architecture}.tbf"), &mut outfile)
+        tab.append_file(format!("{}.tbf", architecture), &mut outfile)
             .unwrap();
     }
 }


### PR DESCRIPTION
This PR makes it possible to tag each elf file with its architecture (`cortex-m...`, `rv32...`).

If the architecture tag is present, the output TBF file's name will be *elf_filename.architecture.tbf* and *architecture.tbf* in the TAB file.
