### PR TITLE
Fix flash address on ARM

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -145,6 +145,32 @@ pub fn elf_to_tbf<W: Write>(
         false
     }
 
+    /// Helper function to find the start section is inside a
+    /// given segment.
+    ///
+    /// This is necessary because the flash segment is not guaranteed 
+    /// to start at the same address as the start section.
+    fn find_start_in_segment<'a>(input: &'a elf::File, segment: &elf::types::ProgramHeader) -> Option<&'a elf::Section> {
+        let segment_start = segment.offset as u32;
+        let segment_size = segment.filesz as u32;
+        let segment_end = segment_start + segment_size;
+
+        for section in input.sections.iter() {
+            let section_start = section.shdr.offset as u32;
+            let section_size = section.shdr.size as u32;
+            let section_end = section_start + section_size;
+
+            if section_start >= segment_start
+                && section_end <= segment_end
+                && section_size > 0
+                && section.shdr.name == ".start"
+            {
+                return Some(section);
+            }
+        }
+        None
+    }
+
     // Do flash address.
     for segment in &input.phdrs {
         match segment.progtype {
@@ -164,11 +190,13 @@ pub fn elf_to_tbf<W: Write>(
                     if segment.vaddr == 0x80000000 {
                         fixed_address_flash_pic = true;
                     } else {
-                        fixed_address_flash = if let Some(prev_addr) = fixed_address_flash {
-                            Some(cmp::min(prev_addr, segment.vaddr as u32))
-                        } else {
-                            Some(segment.vaddr as u32)
-                        }
+                        let start = find_start_in_segment(input, segment)
+                            .map(|section| section.shdr.addr as u32);
+                        fixed_address_flash = match (fixed_address_flash, start) {
+                            (Some(prev_addr), Some(start)) =>
+                                Some(cmp::min(prev_addr, start as u32)),
+                            (prev, start) => prev.or(start),
+                        };
                     }
                 }
             }


### PR DESCRIPTION
ELF files for Arm contain one executable section,
which concides with FLASH in the board layout:

    LOAD off    0x00010000 vaddr 0x00030000 paddr 0x00030000 align 2**16
         filesz 0x00000118 memsz 0x00000118 flags rwx

This doesn't take into account the header size, confusing Tock when attempting to load:

NRF52 HW INFO: Variant: AAC0, Part: N52840, Package: QI, Ram: K256, Flash: K1024
Error loading processes!
App flash does not match requested address. Actual:0x30048, Expected:0x30000

This change finds the flash address based on the .start section
instead of taking the address of the first executable segment.

* * *

Note that this may break if .start is not the first section. However, I don't have any better idea, given ARM's output. RISC-V has sections already aligned to .start:

```
Program Header:
    LOAD off    0x00001000 vaddr 0x20030000 paddr 0x20030000 align 2**12
         filesz 0x00000000 memsz 0x00000048 flags r--
    LOAD off    0x00001048 vaddr 0x20030048 paddr 0x20030048 align 2**12
         filesz 0x000000d8 memsz 0x000000d8 flags r-x
[...]
```

However, I have no idea what causes this, or how to make the ARM target follow this too.

Note that this change is *not enough* to make a working executable. It seems to load, but I don't detect any signs of life in LEDs or rtt.