### PR TITLE
Read stack from elf if available

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -95,10 +95,9 @@ pub struct Opt {
     #[structopt(
         long = "stack",
         name = "stack-size",
-        default_value = "2048",
         help = "in bytes"
     )]
-    pub stack_size: u32,
+    pub stack_size: Option<u32>,
 
     #[structopt(
         long = "app-heap",


### PR DESCRIPTION
The .stack section is declared by binaries, so make use of it before falling back to defaults.

With this change, there's no need to customize the call to elf2tab depending on the application any longer.