### PR TITLE
correct .tbf names in TAB

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ fn main() {
             // `<architecture>.elf` and use the base name as the architecture.
             elf_file
                 .path
-                .file_name()
+                .file_stem()
                 .unwrap()
                 .to_str()
                 .unwrap()


### PR DESCRIPTION
Currently elf2tab when the architecture is not explicitly specified creates a TAB with like so:

```
$ tar --list -f build/blink.tab
metadata.toml
cortex-m0.elf.tbf
cortex-m3.elf.tbf
cortex-m4.elf.tbf
cortex-m7.elf.tbf
```

The architecture TBFs should not include the ".elf". With this change the correct names are in the TAB:

```
$ tar --list -f build/blink.tab
metadata.toml
cortex-m0.tbf
cortex-m3.tbf
cortex-m4.tbf
cortex-m7.tbf
```