### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -145,7 +145,7 @@ impl TbfFooterCredentials {
 }
 
 impl fmt::Display for TbfHeaderBase {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
             "
@@ -159,7 +159,7 @@ impl fmt::Display for TbfHeaderBase {
 }
 
 impl fmt::Display for TbfHeaderMain {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
             "
@@ -172,7 +172,7 @@ impl fmt::Display for TbfHeaderMain {
 }
 
 impl fmt::Display for TbfHeaderProgram {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
             "
@@ -191,7 +191,7 @@ impl fmt::Display for TbfHeaderProgram {
 }
 
 impl fmt::Display for TbfHeaderWriteableFlashRegion {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
             "
@@ -204,7 +204,7 @@ impl fmt::Display for TbfHeaderWriteableFlashRegion {
 }
 
 impl fmt::Display for TbfHeaderFixedAddresses {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
             "
@@ -216,7 +216,7 @@ impl fmt::Display for TbfHeaderFixedAddresses {
 }
 
 impl fmt::Display for TbfHeaderPermissions {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
             "
@@ -237,7 +237,7 @@ impl fmt::Display for TbfHeaderPermissions {
 }
 
 impl fmt::Display for TbfHeaderPersistentAcl {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
             "
@@ -264,7 +264,7 @@ impl fmt::Display for TbfHeaderPersistentAcl {
 }
 
 impl fmt::Display for TbfHeaderKernelVersion {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // ^x.y means >= x.y, < (x+1).0
         writeln!(
             f,
@@ -399,7 +399,7 @@ impl TbfHeader {
             }
         }
 
-        if perms.len() > 0 {
+        if !perms.is_empty() {
             // base
             header_length += mem::size_of::<TbfHeaderTlv>();
             // length
@@ -479,7 +479,7 @@ impl TbfHeader {
             });
         }
 
-        if perms.len() > 0 {
+        if !perms.is_empty() {
             self.hdr_permissions = Some(TbfHeaderPermissions {
                 base: TbfHeaderTlv {
                     tipe: TbfHeaderTypes::Permissions,
@@ -591,7 +591,7 @@ impl TbfHeader {
             init_fn_offset: self.hdr_main.map_or(0, |main| main.init_fn_offset),
             protected_size: self.hdr_main.map_or(0, |main| main.protected_size),
             minimum_ram_size: self.hdr_main.map_or(0, |main| main.minimum_ram_size),
-            binary_end_offset: binary_end_offset,
+            binary_end_offset,
             app_version: 0,
         });
     }
@@ -726,7 +726,7 @@ impl TbfHeader {
 }
 
 impl fmt::Display for TbfHeader {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "TBF Header:")?;
         write!(f, "{}", self.hdr_base)?;
         self.hdr_main.map_or(Ok(()), |hdr| write!(f, "{}", hdr))?;

--- a/src/header.rs
+++ b/src/header.rs
@@ -291,6 +291,12 @@ pub struct TbfHeader {
     package_name_pad: usize,
 }
 
+impl Default for TbfHeader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TbfHeader {
     pub fn new() -> Self {
         Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,23 +34,23 @@ fn main() {
     writeln!(&mut metadata_toml, "name = \"{}\"", package_name).unwrap();
     // Include "minimum-tock-kernel-version" key if a necessary kernel version
     // was specified.
-    minimum_tock_kernel_version.map(|(major, minor)| {
+    if let Some((major, minor)) = minimum_tock_kernel_version {
         writeln!(
             &mut metadata_toml,
             "minimum-tock-kernel-version = \"{}.{}\"",
             major, minor
         )
         .unwrap();
-    });
+    }
     // Include "only-for-boards" key if specific boards were specified.
-    opt.supported_boards.as_ref().map(|supported_boards| {
+    if let Some(supported_boards) = opt.supported_boards.as_ref() {
         writeln!(
             &mut metadata_toml,
             "only-for-boards = \"{}\"",
             supported_boards.as_str()
         )
         .unwrap();
-    });
+    }
     // Add build-date metadata unless a deterministic build is desired.
     if !opt.deterministic {
         let build_date = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
@@ -158,15 +158,12 @@ fn main() {
         )
         .unwrap();
         if opt.verbose {
-            println!("");
+            println!();
         }
 
-        match outfile.write_all(output_vector.as_ref()) {
-            Err(e) => {
-                println!("Failed to write TBF: {:?}", e);
-                return;
-            }
-            _ => {}
+        if let Err(e) = outfile.write_all(output_vector.as_ref()) {
+            println!("Failed to write TBF: {:?}", e);
+            return;
         }
 
         // Add the file to the TAB tar file.

--- a/src/util.rs
+++ b/src/util.rs
@@ -37,28 +37,28 @@ mod test {
     use super::{align_to, amount_alignment_needed};
 
     #[test]
-    pub fn keeps_aligned_values() {
+    fn keeps_aligned_values() {
         let result = align_to(8, 4);
 
         assert_eq!(result, 8);
     }
 
     #[test]
-    pub fn aligns_to_the_next_box() {
+    fn aligns_to_the_next_box() {
         let result = align_to(3, 4);
 
         assert_eq!(result, 4);
     }
 
     #[test]
-    pub fn aligns_to_the_next_box_with_another_box_size() {
+    fn aligns_to_the_next_box_with_another_box_size() {
         let result = align_to(7, 8);
 
         assert_eq!(result, 8);
     }
 
     #[test]
-    pub fn computes_distance_to_lattice_point() {
+    fn computes_distance_to_lattice_point() {
         let result = amount_alignment_needed(7, 8);
 
         assert_eq!(result, 1);


### PR DESCRIPTION
General purpose PR to fix many clippy warnings encountered whilst working on another issue. Changes should be very minimal but code review and extra testing would be appreciated as always! There are 3-4 warnings which I have not fixed as they would require changes I was not comfortable making without input:

- src/util.rs:31 - No safety documentation. I'm not familiar with the use cases of this function so probably can't do this one myself.
- src/convert.rs:34 - Too many arguments in function definition. Could be extracted to a struct?
- src/header.rs:339 - Too many arguments, same as above.

------

_I'm participating in [Hacktoberfest 2022](https://hacktoberfest.com) and if this PR is approved it, it would be greatly appreciated if the PR could be labelled `hacktoberfest-accepted`, or even the repository labelled as `hacktoberfest` to allow PRs in this repository to count towards the competition!_