### PR TITLE
Update elf crate to v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,12 +50,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
-name = "byteorder"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
-
-[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,12 +151,9 @@ dependencies = [
 
 [[package]]
 name = "elf"
-version = "0.0.10"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4841de15dbe0e49b9b62a417589299e3be0d557e0900d36acb87e6dae47197f5"
-dependencies = [
- "byteorder",
-]
+checksum = "2ace2c81c1832d02208b8317b90b2de5b3b4f55024b86d3f2ae800353e348fd7"
 
 [[package]]
 name = "elf2tab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 chrono = "0.4.2"
 clap = { version = "4.0.7", features = ["derive", "color", "wrap_help"] }
 tar = "0.4.36"
-elf = "0.0.10"
+elf = "0.7.1"
 sha2 = "0.10.2"
 ring = "0.16.20"
 rsa-der = "0.3.0"


### PR DESCRIPTION
Note: This is a rework of #60 for the new segment-based conversion logic.

The changes from 0.0.10 -> 0.7.1 represent implementing more complete ELF parsing
functionality, performance improvements for zero-alloc and zero-copy parsing methods,
fuzz testing of the interface, and various bug fixes. v0.7.1 marks the stabilized
release for these changes - i.e. there are no currently planned additional changes
to the library % fixes for any bugs that get reported.

The changes seen in this patch aim to fix it up for the new interface.

The elf crate now supports two parsing modes:

    Parsing lazily out of a &[u8] of the whole file data (the route I chose here)
    Parsing lazily out of a std::io::<Read + Seek> via elf::ElfStream

It seemed to me like this tool inspects a lot of the file data anyway, so the former
is likely faster as opposed to the latter which allows lazy i/o as the parser seeks
around the file parsing things as requested.

This patch successfully built locally and the few unit tests in the crate passed, though there doesn't appear to be coverage of this convert.rs code so I'm not sure what the best way is to verify that this didn't accidentally break something in the actual TAB output.

It seemed to me like this tool inspects a lot of the file data anyway, so the former is likely faster as opposed to the latter which allows lazy i/o as the parser seeks around the file parsing things as requested.