### PR TITLE
Fix relocation data offset in TBF header

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -754,8 +754,14 @@ pub fn elf_to_tbf(
         print!("{}", tbfheader);
     }
 
-    // Write the header and actual app to a binary file.
+    // Write the header to a binary file.
     output.write_all(tbfheader.generate().unwrap().get_ref())?;
+
+    // Adjust the relocation data due to the .ARM.exidx
+    let reldata_start: u32 = binary.len() as u32;
+    binary.as_mut_slice()[32..36].copy_from_slice(&reldata_start.to_le_bytes());
+
+    // Write the actual app to a binary file.
     output.write_all(binary.as_ref())?;
 
     let rel_data_len: [u8; 4] = (relocation_binary.len() as u32).to_le_bytes();


### PR DESCRIPTION
This pull request fixes the offset of the relocation section in the TBF header.

It seems that starting with version 0.10.0, `elf2tab` has a different way of setting up the TBF file from the ELF sections. Before this version, the ARM sections, like `.ARM.exidx` where ignored. They seem to be added now exactly where the relocation section should be. This make apps that include this section to fault. Not all apps have include this section, for instance a simple *hello* does not.

This is how the sections look like:
```
Min RAM size from segments in ELF: 13012 bytes
Number of writeable flash regions: 0
Kernel version: 2.0
  Adding segment. Offset: 72 (0x48). Length: 162972 (0x27c9c) bytes.
    Contains section .crt0_header. Offset: 72 (0x48). Length: 40 (0x28) bytes.
    Contains section .text. Offset: 112 (0x70). Length: 162932 (0x27c74) bytes.
  Adding segment. Offset: 163044 (0x27ce4). Length: 3336 (0xd08) bytes.
    Contains section .got. Offset: 163044 (0x27ce4). Length: 1324 (0x52c) bytes.
    Contains section .data. Offset: 164368 (0x28210). Length: 2012 (0x7dc) bytes.
      Including relocation data (.rel.data). Length: 2488 (0x9b8) bytes.
    Contains section .bss. Offset: 166380 (0x289ec). Length: 9676 (0x25cc) bytes.
  Adding segment. Offset: 166380 (0x289ec). Length: 8 (0x8) bytes.
    Contains section .ARM.exidx. Offset: 166380 (0x289ec). Length: 8 (0x8) bytes.
TBF Header:
               version:        2        0x2
           header_size:       72       0x48
            total_size:   262144    0x40000
                 flags:        1        0x1

        init_fn_offset:       41       0x29
        protected_size:        0        0x0
      minimum_ram_size:    58132     0xE314

        init_fn_offset:       41       0x29
        protected_size:        0        0x0
      minimum_ram_size:    58132     0xE314
     binary_end_offset:   168880    0x293B0
           app_version:        0        0x0

    kernel version: ^2.0
```

I would need this pull request merged for the Rust Nation presentation.

I am not sure that this is the best fix, but it seems to be the fastest. It is interesting that elf2tab now includes a `bss` section. Shouldn't this be excluded?