### PR TITLE
Generate segment padding from ELF-internal offsets

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -549,7 +549,9 @@ pub fn elf_to_tbf(
         if let Some(last_segment_address_end) = last_segment_address_end {
             // We have a previous segment. Now, check if there is any padding
             // between the segments in the .elf.
-            let padding = segment.p_paddr as usize - last_segment_address_end;
+            let padding = (segment.p_offset as usize)
+                .checked_sub(last_segment_address_end)
+                .expect("Invariant violated: expect to iterate over ELF sections in order");
 
             if padding > 0 {
                 if verbose {
@@ -580,6 +582,7 @@ pub fn elf_to_tbf(
 
         let start_segment = segment.p_paddr;
         let end_segment = segment.p_paddr + segment.p_filesz;
+        let end_offset = segment.p_offset + segment.p_filesz;
 
         // Check if this segment contains the entry point, and calculate the
         // offset we need to store in the TBF header if so.
@@ -681,9 +684,9 @@ pub fn elf_to_tbf(
             }
         }
 
-        // Save the end of this segment so we can check if padding is required
-        // between segments.
-        last_segment_address_end = Some(end_segment as usize);
+        // Save the end-offset of this segment within the ELF file, so we can
+        // check if padding is required between segments.
+        last_segment_address_end = Some(end_offset as usize);
 
         binary.extend(content);
         binary_index += segment.p_filesz as usize;


### PR DESCRIPTION
### Pull Request Overview

Previously, `segment.p_addr` was used to generate offsets. Given a specific ordering of ELF segments and certain target memory layouts, this has been observed to insert very large paddings (~256MB), which further break internal offsets in the binary. Instead of the target's addresses, we should be using ELF-file internal offsets to infer padding between segments (which means that the TBF-internal offsets should be equivalent to those of the ELF file itself).

### Testing Strategy

I've tested this with a `libtock-rs` application using a bunch of different linker configurations. Throughout all of these configurations, with this change, `elf2tab` seems to produce binaries that matched the ELF's contents (although some of these apps were still broken for unrelated reasons). Tested with a few `libtock-c` apps as well, although without any linker script changes.