### PR TITLE
Add support for `tbf_protected_region_size` ELF-file symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,14 @@ It can be fixed for all TBFs in the TAB using the command line argument
 `--protected-region-size` (which takes as an argument entire size before the
 application binary, including the TBF header). However, a TAB can include both
 PIC apps and non-PIC apps, and setting the size for all TBFs isn't always
-desirable. Therefore, if `--protected-region-size` is not used, for apps
-compiled for fixed addresses (as determined above) elf2tab will estimate a
-protected region size that tries to ensure the start of the TBF headers _and_
-the application binary are placed at useful addresses in flash. elf2tab will try
-to increase the size of the protected region to make the start of the TBF header
-at an address aligned to 256 bytes when the application binary is at its correct
+desirable. Therefore, elf2tab further supports supplying the protected region
+size through a `tbf_protected_region_size` symbol in the input ELF files. If
+neither this symbol nor `--protected-region-size` are passed, for apps compiled
+for fixed addresses (as determined above) elf2tab will estimate a protected
+region size that tries to ensure the start of the TBF headers _and_ the
+application binary are placed at useful addresses in flash. elf2tab will try to
+increase the size of the protected region to make the start of the TBF header at
+an address aligned to 256 bytes when the application binary is at its correct
 fixed address.
 
 #### Syscall Permissions


### PR DESCRIPTION
### Pull Request Overview

This change causes elf2tab determine the TBF protected region size from a special `tbf_protected_region_size` symbol in the ELF file. This can be overriden through the `--protected-region-size` command line parameter. If neither the parameter nor the symbol are present, elf2tab falls back onto its heuristics for determining a reasonable protected region size.

#### Motivation

For non-PIC apps, it is very inconvenient to need to manually calculate the apps' actual text-section start address, and then choose a protected region parameter on elf2tab's command line which matches the pre-calculated flash address such that the TBF is filled up with headers and padding to match the expected app load address. While many times simply specifying an offset in the link address and allowing elf2tab to fall back onto a reasonable well-aligned address, this mechanism can break under some configurations. The following outlines how a PIC and non-PIC target is defined in `libtock-c`:

```
TOCK_TARGETS ?= cortex-m0\
                [...]
                rv32imac|rv32imac.0x20040060.0x80002800|0x20040060|0x80002800\
```

(Here, the intended load address for the application is `0x20040000`. To generate correct binaries, `0x60` is added as an offset to the linker-provided flash address. Deverlopers either rely on elf2tab automatically falling back onto the next-lower 256-byte aligned address, or must pass `--protected-region-size 0x60` to elf2tab.)

`libtock-rs` currently takes a different approach[1]: it reserves a section for the TBF headers at the start of its flash region. However, this does not seem to work reliably. For instance, the linker is free to re-arrange segments in the ELF file, and e.g., have the RAM segment located before the flash segment. While TBF is compatible with that (by setting the `init_fn_offset` field properly), having the TBF header reservation at the front of the `FLASH` segment (which is not the first segment in the ELF file) would break the assumption that the TBF header precedes the actual process binary. Furthermore, the current ELF parsing logic interprets this `.tbf_header` section as the start of application flash and prepends TBF headers before that section.

By introducing support for a `tbf_protected_region_size` symbol (which can be set to an arbitrary value outside of any ELF segment), applications can place their `FLASH` segment at an appropriate offset and hint this offset to `elf2tab`, without placing any constraints on the ELF segment layout itself.

[1]: https://github.com/tock/libtock-rs/blob/0f7c97627b7d49dd34129d40717eadba9d307a2d/runtime/libtock_layout.ld#L50-L54

### Testing Strategy

These changes are tested with a preliminary integration into the linker-scripts of the `libtock-c` and `libtock-rs` toolchains.