### PR TITLE
Update based on clippy warnings

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -972,12 +972,11 @@ pub fn elf_to_tbf(
                 panic!("Could not generate RSA4096 signature: {:?}", e);
             });
         let mut credentials = vec![0; 1024];
-        for i in 0..key_pair.public_modulus_len() {
-            credentials[i] = public_modulus[i];
-        }
-        for i in 0..signature.len() {
+        credentials[..key_pair.public_modulus_len()]
+            .copy_from_slice(&public_modulus[..key_pair.public_modulus_len()]);
+        for (i, sig) in signature.iter().enumerate() {
             let index = i + key_pair.public_modulus_len();
-            credentials[index] = signature[i];
+            credentials[index] = *sig;
         }
 
         let rsa4096_credentials = header::TbfFooterCredentials {
@@ -1019,7 +1018,7 @@ pub fn elf_to_tbf(
     }
 
     // Pad to get a power of 2 sized flash app, if requested.
-    util::do_pad(output, post_content_pad as usize)?;
+    util::do_pad(output, post_content_pad)?;
 
     Ok(())
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -399,7 +399,7 @@ impl TbfHeader {
             }
         }
 
-        if perms.len() > 0 {
+        if !perms.is_empty() {
             // base
             header_length += mem::size_of::<TbfHeaderTlv>();
             // length
@@ -479,7 +479,7 @@ impl TbfHeader {
             });
         }
 
-        if perms.len() > 0 {
+        if !perms.is_empty() {
             self.hdr_permissions = Some(TbfHeaderPermissions {
                 base: TbfHeaderTlv {
                     tipe: TbfHeaderTypes::Permissions,
@@ -591,7 +591,7 @@ impl TbfHeader {
             init_fn_offset: self.hdr_main.map_or(0, |main| main.init_fn_offset),
             protected_size: self.hdr_main.map_or(0, |main| main.protected_size),
             minimum_ram_size: self.hdr_main.map_or(0, |main| main.minimum_ram_size),
-            binary_end_offset: binary_end_offset,
+            binary_end_offset,
             app_version: 0,
         });
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -28,6 +28,11 @@ pub fn do_pad<W: io::Write>(output: &mut W, length: usize) -> io::Result<()> {
     Ok(())
 }
 
+/// Get a raw buffer for the memory of type `T`.
+///
+/// # Safety
+///
+/// This must only be used to write the object to the output file.
 pub unsafe fn as_byte_slice<T: Copy>(input: &T) -> &[u8] {
     slice::from_raw_parts(input as *const T as *const u8, mem::size_of::<T>())
 }


### PR DESCRIPTION
I ran `cargo clippy` and fixed some of the warnings.

The "too many arguments" warnings are not useful.

I don't want to change `section_in_segment()` because it is from another source and I don't want them to diverge more than necessary.

Update from #59.