### PR TITLE
Revert "Generate segment padding from ELF-internal offsets"

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -549,9 +549,7 @@ pub fn elf_to_tbf(
         if let Some(last_segment_address_end) = last_segment_address_end {
             // We have a previous segment. Now, check if there is any padding
             // between the segments in the .elf.
-            let padding = (segment.p_offset as usize)
-                .checked_sub(last_segment_address_end)
-                .expect("Invariant violated: expect to iterate over ELF sections in order");
+            let padding = segment.p_paddr as usize - last_segment_address_end;
 
             if padding > 0 {
                 if verbose {
@@ -582,7 +580,6 @@ pub fn elf_to_tbf(
 
         let start_segment = segment.p_paddr;
         let end_segment = segment.p_paddr + segment.p_filesz;
-        let end_offset = segment.p_offset + segment.p_filesz;
 
         // Check if this segment contains the entry point, and calculate the
         // offset we need to store in the TBF header if so.
@@ -684,9 +681,9 @@ pub fn elf_to_tbf(
             }
         }
 
-        // Save the end-offset of this segment within the ELF file, so we can
-        // check if padding is required between segments.
-        last_segment_address_end = Some(end_offset as usize);
+        // Save the end of this segment so we can check if padding is required
+        // between segments.
+        last_segment_address_end = Some(end_segment as usize);
 
         binary.extend(content);
         binary_index += segment.p_filesz as usize;


### PR DESCRIPTION
This reverts commit d89f703bb4e725224770ac2a57d8bd69747de4c4. Ultimately, the underlying issue motivating these changes seems to be a linker bug, as documented in libtock-rs PR tock/libtock-rs#477 [1]. Indeed, we should follow the physical addresses as specified in the ELF file to generate padding, meaning that the previous code was correct.

However, there's two invariants which elf2tab should ensure still:

- the libtock-rs bug seems to indicate that the section placement in ELF files does not necessarily have to correlate to their physical (load) address. It appears to be valid for ELF files to list sections in an arbitrary order, and thus elf2tab should presumably sort sections by their physical address (intended load address), and then walk them and insert padding as necessary.

- the confusing behavior which lead to this incorrect bugfix was that elf2tab generated a very large (> 256MB) TBF. To ensure that this does not happen, we can introduce sanity checks.

  elf2tab acts as the Tock application loader, by placing apps into memory such that they can be executed in place. This means that the physical address of all LOADed segments must be within the board's FLASH address space. We can have elf2tab issue a warning if there is an excessive amount of space (>= 4kB) between the physical (load) end address of one segment, and the start address of the next. This prevents linker script bugs from creeping into elf2tab undetected, and cause it to blindly generate nonsensical binaries.

[1]: https://github.com/tock/libtock-rs/pull/477