### PR TITLE
Update dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ name = "elf2tab"
 path = "src/main.rs"
 
 [dependencies]
-chrono = { version = "0.4.2", default-features = false, features = ["clock", "std"] }
-clap = { version = "4.0.7", features = ["derive", "color", "wrap_help"] }
-tar = "0.4.36"
-elf = "0.7.1"
-sha2 = "0.10.2"
+chrono = { version = "0.4.26", default-features = false, features = ["clock", "std"] }
+clap = { version = "4.3.17", features = ["derive", "color", "wrap_help"] }
+tar = "0.4.39"
+elf = "0.7.2"
+sha2 = "0.10.7"
 ring = "0.16.20"
 rsa-der = "0.3.0"


### PR DESCRIPTION
I ran:

```
$ cargo install cargo-edit
$ cargo upgrade
```

Output:

```
$ cargo upgrade
    Updating 'https://github.com/rust-lang/crates.io-index' index
    Checking elf2tab's dependencies
name   old req compatible latest new req
====   ======= ========== ====== =======
chrono 0.4.2   0.4.26     0.4.26 0.4.26
clap   4.0.7   4.3.17     4.3.17 4.3.17
tar    0.4.36  0.4.39     0.4.39 0.4.39
elf    0.7.1   0.7.2      0.7.2  0.7.2
sha2   0.10.2  0.10.7     0.10.7 0.10.7
   Upgrading recursive dependencies
note: Re-run with `--verbose` to show more dependencies
  latest: ring, rsa-der
```