### PR TITLE
modify segments that start before flash

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -633,6 +633,15 @@ pub fn elf_to_tbf(
             continue;
         }
 
+        // Check if the segment starts entirely before the start of flash. If
+        // so, skip this segment.
+        if let Some(flash_address) = fixed_address_flash {
+            let flash_address: u64 = flash_address as u64;
+            if segment.p_paddr + segment.p_filesz < flash_address {
+                continue;
+            }
+        }
+
         // It's possible the linker started this segment _before_ the start of
         // the flash region. We edit the segment to remove the portion that
         // starts before the start of flash.


### PR DESCRIPTION
This is an alternative to #74.

The linker appears to be able to place segments before the start of flash. We detect this case and edit the segment to remove the portion that exists before the specified start of flash.

This if merged would be the end of an era: I've finally given in to use symbols to transfer information from the linker script to elf2tab.