### PR TITLE
Reverted ring version to 0.16.20 (rsakey-pk8)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ clap = { version = "4.0.7", features = ["derive", "color", "wrap_help"] }
 tar = "0.4.36"
 elf = "0.7.1"
 sha2 = "0.10.2"
-ring = { git="https://github.com/briansmith/ring", rev = "95948b3977013aed16db92ae32e6b8384496a740" }
+ring = "0.16.20"


### PR DESCRIPTION
On PR #78 I wasn't able to compile `ring` on Windows, so I reverted it back to 0.16.20

For some reason `ring` seems to fail at getting running `nasm`. From the look of things, it tries to run the `nasm` executable from `./target/tools/nasm/nasm`, but no such executable is created there. When I downloaded the latest `nasm.exe` from their website, I tried adding it to PATH, but still no luck. I manually created the directory and placed the nasm.exe executable there, and it still didn't recognize it as being there. Even after renaming it from `nasm.exe` to just `nasm`, I still wasn't able to compile.

```bash
   Compiling ring v0.17.0-not-released-yet (https://github.com/briansmith/ring?rev=95948b3977013aed16db92ae32e6b8384496a740#95948b39)
error: failed to run custom build command for `ring v0.17.0-not-released-yet (https://github.com/briansmith/ring?rev=95948b3977013aed16db92ae32e6b8384496a740#95948b39)`

Caused by:
  process didn't exit successfully: `D:\Programming\elf2tab\target\debug\build\ring-fed2821da4499784\build-script-build` (exit code: 101)
  --- stdout
  cargo:rerun-if-env-changed=RING_PREGENERATE_ASM
  cargo:rustc-env=RING_CORE_PREFIX=ring_core_0_17_0_not_released_yet_
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE
  cargo:rerun-if-env-changed=PERL_EXECUTABLE

  --- stderr
  running "perl" "crypto/chacha/asm/chacha-x86_64.pl" "nasm" "D:/Programming/elf2tab/target/debug/build/ring-a3a7ea799563ac03/out/chacha-x86_64-nasm.asm"
  running "perl" "crypto/fipsmodule/aes/asm/aesni-x86_64.pl" "nasm" "D:/Programming/elf2tab/target/debug/build/ring-a3a7ea799563ac03/out/aesni-x86_64-nasm.asm"
  running "perl" "crypto/fipsmodule/aes/asm/vpaes-x86_64.pl" "nasm" "D:/Programming/elf2tab/target/debug/build/ring-a3a7ea799563ac03/out/vpaes-x86_64-nasm.asm"
  running "perl" "crypto/fipsmodule/bn/asm/x86_64-mont.pl" "nasm" "D:/Programming/elf2tab/target/debug/build/ring-a3a7ea799563ac03/out/x86_64-mont-nasm.asm"
  running "perl" "crypto/fipsmodule/bn/asm/x86_64-mont5.pl" "nasm" "D:/Programming/elf2tab/target/debug/build/ring-a3a7ea799563ac03/out/x86_64-mont5-nasm.asm"
  running "perl" "crypto/fipsmodule/ec/asm/p256-x86_64-asm.pl" "nasm" "D:/Programming/elf2tab/target/debug/build/ring-a3a7ea799563ac03/out/p256-x86_64-asm-nasm.asm"
  running "perl" "crypto/fipsmodule/modes/asm/aesni-gcm-x86_64.pl" "nasm" "D:/Programming/elf2tab/target/debug/build/ring-a3a7ea799563ac03/out/aesni-gcm-x86_64-nasm.asm"
  running "perl" "crypto/fipsmodule/modes/asm/ghash-x86_64.pl" "nasm" "D:/Programming/elf2tab/target/debug/build/ring-a3a7ea799563ac03/out/ghash-x86_64-nasm.asm"
  running "perl" "crypto/fipsmodule/sha/asm/sha512-x86_64.pl" "nasm" "D:/Programming/elf2tab/target/debug/build/ring-a3a7ea799563ac03/out/sha512-x86_64-nasm.asm"
  running "perl" "crypto/cipher_extra/asm/chacha20_poly1305_x86_64.pl" "nasm" "D:/Programming/elf2tab/target/debug/build/ring-a3a7ea799563ac03/out/chacha20_poly1305_x86_64-nasm.asm"     
  running "perl" "crypto/fipsmodule/sha/asm/sha512-x86_64.pl" "nasm" "D:/Programming/elf2tab/target/debug/build/ring-a3a7ea799563ac03/out/sha256-x86_64-nasm.asm"
  running "./target/tools/windows/nasm/nasm" "-o" "D:\\Programming\\elf2tab\\target\\debug\\build\\ring-a3a7ea799563ac03\\out\\chacha-x86_64-nasm.o" "-f" "win64" "-i" "include/" "-i" "D:\\Programming\\elf2tab\\target\\debug\\build\\ring-a3a7ea799563ac03\\out\\" "-Xgnu" "-gcv8" "D:\\Programming\\elf2tab\\target\\debug\\build\\ring-a3a7ea799563ac03\\out\\chacha-x86_64-nasm.asm"
  thread 'main' panicked at 'failed to execute ["./target/tools/windows/nasm/nasm" "-o" "D:\\Programming\\elf2tab\\target\\debug\\build\\ring-a3a7ea799563ac03\\out\\chacha-x86_64-nasm.o" "-f" "win64" "-i" "include/" "-i" "D:\\Programming\\elf2tab\\target\\debug\\build\\ring-a3a7ea799563ac03\\out\\" "-Xgnu" "-gcv8" "D:\\Programming\\elf2tab\\target\\debug\\build\\ring-a3a7ea799563ac03\\out\\chacha-x86_64-nasm.asm"]: The system cannot find the path specified. (os error 3)', C:\Users\<user>\.cargo\git\checkouts\ring-51509f604a4fd25b\95948b3\build.rs:707:9   
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

```

After signing the same elf file, using the same key, the final `.tbf` file for both WSL and Windows are the same as the one emitted in PR #78 on WSL. More so, it is the same as the one created on master for both WSL and Windows (key and .der file generated on Windows. If generated on WSL, signing does not work)
