### PR TITLE
cmdline: support hex numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-num"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488557e97528174edaa2ee268b23a809e0c598213a4bbcb4f34575a46fda147e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +230,7 @@ version = "0.12.0-dev"
 dependencies = [
  "chrono",
  "clap",
+ "clap-num",
  "elf",
  "ring",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 [dependencies]
 chrono = { version = "0.4.26", default-features = false, features = ["clock", "std"] }
 clap = { version = "4.3.17", features = ["derive", "color", "wrap_help"] }
+clap-num = "1.0.2"
 tar = "0.4.39"
 elf = "0.7.2"
 sha2 = "0.10.7"

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -134,7 +134,8 @@ pub struct Opt {
     #[arg(
         long = "write_id",
         id = "write_id",
-        help = "A storage ID used for writing data"
+        help = "A storage ID used for writing data",
+        value_parser=clap_num::maybe_hex::<u32>,
     )]
     pub write_id: Option<u32>,
 
@@ -143,6 +144,7 @@ pub struct Opt {
         id = "read_ids",
         help = "Storage IDs that this app is allowed to read",
         num_args = 1..,
+        value_parser=clap_num::maybe_hex::<u32>,
     )]
     pub read_ids: Option<Vec<u32>>,
 
@@ -151,6 +153,7 @@ pub struct Opt {
         id = "access_ids",
         help = "Storage IDs that this app is allowed to write",
         num_args = 1..,
+        value_parser=clap_num::maybe_hex::<u32>,
     )]
     pub access_ids: Option<Vec<u32>>,
 


### PR DESCRIPTION
Support commands like `elf2tab --write_id 0x10`.