### PR TITLE
Align kernel version debug print

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -269,7 +269,7 @@ impl fmt::Display for TbfHeaderKernelVersion {
         writeln!(
             f,
             "
-    kernel version: ^{}.{}",
+        kernel version: ^{}.{}",
             self.major, self.minor
         )
     }


### PR DESCRIPTION
Before:

```text
               version:        2        0x2
           header_size:       96       0x60
            total_size:    11628     0x2D6C
                 flags:        1        0x1

        init_fn_offset:       72       0x48
        protected_size:       32       0x20
      minimum_ram_size:     4872     0x1308

        init_fn_offset:       72       0x48
        protected_size:       32       0x20
      minimum_ram_size:     4872     0x1308
     binary_end_offset:     8628     0x21B4
           app_version:        0        0x0

     start_process_ram: 2147512320 0x80007000
   start_process_flash: 1078198400 0x40440080

    kernel version: ^2.0
```

After:

```text
               version:        2        0x2
           header_size:       88       0x58
            total_size:     4228     0x1084
                 flags:        1        0x1

        init_fn_offset:       80       0x50
        protected_size:       40       0x28
      minimum_ram_size:     4876     0x130C

        init_fn_offset:       80       0x50
        protected_size:       40       0x28
      minimum_ram_size:     4876     0x130C
     binary_end_offset:     1228      0x4CC
           app_version:        0        0x0

     start_process_ram: 2147512320 0x80007000
   start_process_flash: 1078198400 0x40440080

        kernel version: ^2.0
```