### PR TITLE
Also consider RO data for start of flash

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -351,9 +351,9 @@ pub fn elf_to_tbf(
                 continue;
             }
 
-            // Flash segments have to be marked executable, and we only care about
+            // Flash segments have to be marked read-only, and we only care about
             // segments that actually contain data to be loaded into flash.
-            if (segment.p_flags & elf::abi::PF_X) > 0
+            if (segment.p_flags & elf::abi::PF_W) == 0
                 && section_exists_in_segment(&elf_sections, segment)
             {
                 // If this is standard Tock PIC, then this virtual address will be


### PR DESCRIPTION
Take read-only data segments into account when determining where flash contents start. This is specifically important if the Tock CRT0 header is in a separate data section before the start of `.text`.

The change is trivial and fixes https://github.com/tock/elf2tab/issues/92 for me, but would benefit from someone else thinking the logic through in case I missed some unintended consequences. I am not entirely clear on why elf2tab does some of the things it does...