### PR TITLE
Cortex-m MPU subregions for >64KB apps

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -187,21 +187,10 @@ pub fn elf_to_tbf(
         TotalSizePowerOfTwo,
         /// Make sure the entire TBF is a multiple of a specific value.
         TotalSizeMultiple(usize),
+        /// To prevent wasted space, only pad to:
+        /// (X - 1) * (TotalSizePowerOfTwo / 8) < size < X * (TotalSizePowerOfTwo / 8)
+        MaskedPowerOfTwo,
     }
-
-    // Add trailing padding for certain architectures.
-    //
-    // - ARM: make sure the entire TBF is a power of 2 to make configuring the
-    //   MPU easy.
-    // - RISC_V: make sure the entire TBF is a multiple of 4 to meet TBF
-    //   alignment requirements.
-    // - x86: use 4k padding to match page size.
-    let trailing_padding = match elf_file.ehdr.e_machine {
-        elf::abi::EM_ARM => Some(TrailingPadding::TotalSizePowerOfTwo),
-        elf::abi::EM_RISCV => Some(TrailingPadding::TotalSizeMultiple(4)),
-        elf::abi::EM_386 => Some(TrailingPadding::TotalSizeMultiple(4096)),
-        _ => None,
-    };
 
     ////////////////////////////////////////////////////////////////////////////
     // Determine the amount of RAM this app needs.
@@ -897,6 +886,30 @@ pub fn elf_to_tbf(
         ensured_footer_reserved_space = true;
     }
 
+    // Add trailing padding for certain architectures.
+    // - ARM: make sure the entire TBF is a power of 2 to make configuring the
+    //   MPU easy and to make using the generated TBFs directly easy (for apps <64kB).
+    //   However, for larger apps (i.e., apps >64kB) round up to the
+    //   nearest power of 2 and then use subregions to limit wasted flash.
+    //   This is still compatible with the MPU but may make using multiple TBFs
+    //   more difficult due to alignment restrictions.
+    // - RISC_V: make sure the entire TBF is a multiple of 4 to meet TBF
+    //   alignment requirements.
+    // - x86: use 4k padding to match page size.
+    let trailing_padding = match elf_file.ehdr.e_machine {
+        elf::abi::EM_ARM => {
+            // Do power of two padding if less than 64KB, otherwise do masked.
+            if binary_index < 65536 {
+                Some(TrailingPadding::TotalSizePowerOfTwo)
+            } else {
+                Some(TrailingPadding::MaskedPowerOfTwo)
+            }
+        }
+        elf::abi::EM_RISCV => Some(TrailingPadding::TotalSizeMultiple(4)),
+        elf::abi::EM_386 => Some(TrailingPadding::TotalSizeMultiple(4096)),
+        _ => None,
+    };
+
     // Optionally calculate the additional padding needed to ensure the app size
     // meets the padding requirements.
     //
@@ -920,6 +933,16 @@ pub fn elf_to_tbf(
             }
             TrailingPadding::TotalSizeMultiple(multiple) => {
                 (multiple - (binary_index % multiple)) % multiple
+            }
+            TrailingPadding::MaskedPowerOfTwo => {
+                // Find the next power of two.
+                let next_power2 = 1 << (32 - (binary_index as u32).leading_zeros());
+                let multiple = next_power2 / 8;
+                let number_of_unmasked_subregions = binary_index.div_ceil(multiple);
+                let target_size = number_of_unmasked_subregions * multiple;
+
+                // Pad to the nearest multiple of (power of two / 8).
+                target_size - binary_index
             }
         };
 


### PR DESCRIPTION
Rounding to the nearest power of two for cortex-m apps results in a high amount of flash wasting for large applications. This adds logic to take advantage of MPU subregions for apps larger than 64kB. 

## Example

For an ~80kB application the tab was padded to 128kB before these changes.

```
Application size report for arch family cortex-m:
   text	   data	    bss	    dec	    hex	filename
  81564	   5152	   6168	  92884	  16ad4	build/cortex-m0/cortex-m0.elf
  76440	   5128	   6168	  87736	  156b8	build/cortex-m3/cortex-m3.elf
  76608	   5128	   6168	  87904	  15760	build/cortex-m4/cortex-m4.elf
  76656	   5128	   6168	  87952	  15790	build/cortex-m7/cortex-m7.elf
 311268	  20536	  24672	 356476	  5707c	(TOTALS)
```

### Before Changes

```
cortex-m4:
  TBF version           : 2                       [0x0  ]
  header_size           :         76         0x4c
  total_size            :     131072      0x20000 <==== TOTAL APP SIZE IN FLASH
  checksum              :              0x6148427d
  flags                 :          1          0x1
    enabled             : Yes
    sticky              : No
  TLV: Main (1)                                   [0x10 ]
    init_fn_offset      :         49         0x31
    protected_size      :          0          0x0
    minimum_ram_size    :      16436       0x4034
  TLV: Program (9)                                [0x20 ]
    init_fn_offset      :         49         0x31
    protected_size      :          0          0x0
    minimum_ram_size    :      16436       0x4034
    binary_end_offset   :      85092      0x14c64
    app_version         :          0          0x0
  TLV: Package Name (3)                           [0x38 ]
    package_name        : lorawan
  TLV: Kernel Version (8)                         [0x44 ]
    kernel_major        : 2
    kernel_minor        : 0
    kernel version      : ^2.0

TBF Footers
  Footer
    footer_size         :      45980       0xb39c
  Footer TLV: Credentials (128)                   [0x0  ]
    Type: Reserved (0)
    Length: 45972 <========= PADDING ADDED
```

### After Changes
```
cortex-m4:
  TBF version           : 2                       [0x0  ]
  header_size           :         76         0x4c
  total_size            :      98304      0x18000 <===== TOTAL APP SIZE IN FLASH
  checksum              :              0x614bc30d
  flags                 :          1          0x1
    enabled             : Yes
    sticky              : No
  TLV: Main (1)                                   [0x10 ]
    init_fn_offset      :         49         0x31
    protected_size      :          0          0x0
    minimum_ram_size    :      13344       0x3420
  TLV: Program (9)                                [0x20 ]
    init_fn_offset      :         49         0x31
    protected_size      :          0          0x0
    minimum_ram_size    :      13344       0x3420
    binary_end_offset   :      85268      0x14d14
    app_version         :          0          0x0
  TLV: Package Name (3)                           [0x38 ]
    package_name        : lorawan
  TLV: Kernel Version (8)                         [0x44 ]
    kernel_major        : 2
    kernel_minor        : 0
    kernel version      : ^2.0

TBF Footers
  Footer
    footer_size         :      13036       0x32ec
  Footer TLV: Credentials (128)                   [0x0  ]
    Type: Reserved (0)
    Length: 13028 <============== PADDING ADDED 
```

